### PR TITLE
feat(view): add list-multi-project-workitem command + v1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.2] - 2026-05-14
+
+### Added
+
+- New `view list-multi-project-workitems` command exposing the upstream `list_multi_project_view_workitems` MCP tool — lists work items the caller can access under a multi-project ("panoramic") view, identified by a `multiProjectView` URL's `view_id`; takes `--project-key`, `--view-id`, and an optional `--page-num` (50 items per page, 1-based)
+- Top-level parameters merged via `--params` / `--set` are now validated against the tool's declared flag set. Unknown arguments emit a one-line stderr warning at run time and appear under `validation.unknown_params` in `--dry-run` output, pointing users at `--params '{"fields":[...]}'` for work-item field values. Validation is advisory: unknown keys are still forwarded to the backend so a stale local tool-schema cache cannot block legitimate calls (refresh with `--refresh`)
+
+### Changed
+
+- Clarified `--params` documentation: the built-in flag's `--help` description and the README now state that top-level keys are merged as CLI flags (not a free-form payload), with a common-pitfall example showing that work-item field values must be wrapped in `fields[]`
+
 ## [v1.0.1] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Command-line tool for [Meegle](https://meegle.com?utm_source=github&utm_medium=r
 ## Why Meegle CLI?
 
 - **Agent-Native** — Ships a bundled [AI Agent Skill](#ai-agent-skill) that teaches Trae, Claude Code, Cursor, Windsurf, Gemini CLI and other agents how to drive Meegle with one command. Every CLI command is designed for both humans and agents, with structured JSON output, `--dry-run` previews, and `--device-code` flows for non-TTY environments
-- **Broad Coverage** — 12 business domains (work items, workflow, subtasks, comments, work hours, relations, my-work, views, charts, team, user, project) and 40+ commands mapping to Meegle's core capabilities
+- **Broad Coverage** — 13 business domains (work items, workflow, subtasks, comments, work hours, relations, my-work, views, charts, team, user, project, attachments) and 40+ commands mapping to Meegle's core capabilities
 - **Two-Layer Parameters** — Ergonomic `--flag-name` for everyday use, fallback `--params <json>` for complex payloads like `fields[]` — pick the right granularity per call
 - **Flexible Output** — `json` / `table` / `ndjson` / `raw`, with `--select` dot-path projection for piping to other tools
 - **Secure by Default** — OS keychain credential storage, `${VAR}` env-var templating so secrets never land in config files, multi-profile switching for staging / prod
@@ -33,6 +33,7 @@ Command-line tool for [Meegle](https://meegle.com?utm_source=github&utm_medium=r
 | 📊 [Charts](#chart--charts)                        | List charts under a view, fetch chart details                                                  |
 | 👥 [Team & User](#team--user--people)              | List teams, team members, search users, view current login                                     |
 | 🗂️ [Projects](#project--projects)                  | Search projects by keyword                                                                     |
+| 📎 [Attachments](#attachment--attachments)         | Two-stage upload/download protocol — `prepare-*` basic commands plus `+upload` / `+download` end-to-end shortcuts |
 | 🔐 [Auth & Config](#authentication)                | OAuth login, device-code flow, multi-profile config, env-var injection                         |
 | 🔗 [URL Parsing](#url--url-parsing)                | Offline decode of Meegle / Feishu Project URLs into `url_kind` + structured fields             |
 | 🤖 [Agent Skill](#ai-agent-skill)                  | Pre-built skill for Trae / Claude Code / Cursor / Windsurf / Gemini CLI / Copilot              |
@@ -220,6 +221,7 @@ The agent consults the skill, picks the right `meegle` commands, and runs them f
 | `view get` | View details of a view |
 | `view update-fixed` | Update a fixed view |
 | `view search` | Search views by name |
+| `view list-multi-project-workitems` | List work items under a multi-project (panoramic) view |
 
 ### chart — Charts
 
@@ -509,17 +511,6 @@ Each command takes parameters via `--flag-name`:
 meegle workitem get --work-item-id 12345 --project-key PROJ
 ```
 
-### Writing `fields[]` (Write Commands)
-
-`workitem create`, `workitem update`, `workflow update-node`, and `subtask update` expect the `fields[]` payload. Pass it through `--params`:
-
-```bash
---params '{"fields":[
-  {"field_key":"name","field_value":"Title"},
-  {"field_key":"priority","field_value":"P1"}
-]}'
-```
-
 ### --set key=value (Generic)
 
 `--set` is an alternate syntax for writing **top-level** parameters — `--set key=value` is equivalent to typing `--key value`. Useful when scripting with a uniform `key=value` form, or for writing nested top-level params via dot-path. Values are auto-typed (int / float / bool / string).
@@ -535,14 +526,50 @@ meegle mywork todo --set action=this_week --set page_num=1
 
 `--set` only writes **top-level** parameters. To write a work item's `fields[]`, use `--params '{"fields":[...]}'` (see below).
 
-### --params JSON (Fallback)
+### --params JSON
 
-All commands support `--params` to pass a full JSON parameter body:
+`--params` takes a JSON object; **each top-level key is merged in as a CLI flag**.
+The key must be a valid flag of the current command — it is not a free-form payload.
+
+```bash
+# These two are equivalent:
+meegle workitem get --work-item-id 12345 --project-key PROJ
+meegle workitem get --params '{"work_item_id":12345,"project_key":"PROJ"}'
+```
+
+Use `--params` when:
+
+- the value is a nested object or array (`fields[]`, `schedule{}`) — too awkward to inline as a flag
+- you want to set many parameters at once, or feed a payload from a file (see `@file.json` below)
 
 ```bash
 meegle workitem create --project-key PROJ --work-item-type story \
   --params '{"fields":[{"field_key":"name","field_value":"Title"}]}'
 ```
+
+#### Common pitfall: not every name is a top-level flag
+
+Some values that *look* like top-level fields are actually work-item field
+values, and must be wrapped in `fields[]` rather than placed at the top
+level. For example, on `workitem update` the `priority` value belongs to
+the work item's fields, not to the command's flags:
+
+```bash
+# ❌ "priority" is not a flag of workitem update — CLI prints a stderr warning, backend ignores it
+meegle workitem update --work-item-id 12345 --params '{"priority":"P1"}'
+
+# ✓ Wrap field values inside fields[]
+meegle workitem update --work-item-id 12345 \
+  --params '{"fields":[{"field_key":"priority","field_value":"P1"}]}'
+```
+
+The CLI surfaces unknown top-level keys as a `validation.unknown_params`
+list under `--dry-run`, and as a one-line stderr warning at run time. They
+are still forwarded to the backend (in case your local tool-schema cache
+is stale — refresh with `--refresh`).
+
+Run `meegle workitem meta-fields --project-key PK --work-item-type TK`
+to look up valid `field_key`s for a work item type.
 
 #### Reading from a file (`@file.json`)
 
@@ -748,7 +775,7 @@ export MEEGLE_USER_AGENT=ci-runner  # optional; appended to User-Agent, highest 
 meegle workitem get --work-item-id 123
 ```
 
-Either variable may be set independently. When this path is taken, the CLI bypasses the keychain and does not attempt to refresh on 401 — the caller is responsible for rotating the env value.
+Either variable may be set independently. When `MEEGLE_USER_ACCESS_TOKEN` is set, the CLI bypasses the keychain and does not attempt to refresh on 401 — the caller is responsible for rotating the env value. Setting only `MEEGLE_HOST` (without a token) still uses the keychain-stored credentials.
 
 ### Custom Auth Header
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 ## 为什么选择 Meegle CLI？
 
 - **Agent 友好** — 附带一份 [AI Agent Skill](#ai-agent-skill)，一条命令即可把 Meegle 操作手册喂给 Trae、Claude Code、Cursor、Windsurf、Gemini CLI 等主流 Agent。CLI 命令同时面向人类和 Agent 设计，结构化 JSON 输出、`--dry-run` 预览、`--device-code` 无 TTY 流程
-- **覆盖完整** — 12 个业务域（工作项、工作流、子任务、评论、工时、关联、我的工作、视图、图表、团队、用户、空间），40+ 命令映射到 Meegle 核心能力
+- **覆盖完整** — 13 个业务域（工作项、工作流、子任务、评论、工时、关联、我的工作、视图、图表、团队、用户、空间、附件），40+ 命令映射到 Meegle 核心能力
 - **两层参数模型** — 日常用 `--flag-name` 轻便直接，复杂载荷（如 `fields[]`）用 `--params <json>` 兜底 —— 按场景选择合适粒度
 - **输出格式灵活** — 支持 `json` / `table` / `ndjson` / `raw`，配合 `--select` 点路径投影可直接 pipe 给其他工具
 - **默认安全** — 凭证存进系统 keychain、`${VAR}` 环境变量模板让 secret 不落地到 config 文件、多 profile 分离 staging / prod
@@ -33,6 +33,7 @@
 | 📊 [图表](#chart--度量域)                          | 列出视图下的图表、查看图表详情                                                           |
 | 👥 [团队与用户](#team--user--人员域)               | 列出团队、团队成员、搜索用户、查看当前登录身份                                           |
 | 🗂️ [空间](#project--空间域)                        | 按关键词搜索空间                                                                         |
+| 📎 [附件](#attachment--附件域)                     | 两段式上传/下载协议 —— `prepare-*` 基础命令 + `+upload` / `+download` 端到端快捷命令     |
 | 🔐 [认证与配置](#认证)                             | OAuth 登录、Device Code 流程、多 profile 配置、环境变量注入                              |
 | 🔗 [URL 解析](#url--url-解析)                      | 离线解析飞书项目 / Meegle URL，输出 `url_kind` + 结构化字段                              |
 | 🤖 [Agent Skill](#ai-agent-skill)                  | 内置 skill 供 Trae / Claude Code / Cursor / Windsurf / Gemini / Copilot 使用             |
@@ -220,6 +221,7 @@ Agent 会参考 skill，自动选择合适的 `meegle` 命令执行。配合 `--
 | `view get` | 查看视图详情 |
 | `view update-fixed` | 更新固定视图 |
 | `view search` | 按名称搜索视图 |
+| `view list-multi-project-workitems` | 查看全景视图（multiProjectView）下的工作项列表 |
 
 ### chart — 度量域
 
@@ -501,17 +503,6 @@ meegle user search --user-keys "张三,李四" --project-key PROJ
 meegle workitem get --work-item-id 12345 --project-key PROJ
 ```
 
-### 写 `fields[]`（写入命令）
-
-`workitem create`、`workitem update`、`workflow update-node`、`subtask update` 需要传 `fields[]`，通过 `--params` 走：
-
-```bash
---params '{"fields":[
-  {"field_key":"name","field_value":"标题"},
-  {"field_key":"priority","field_value":"P1"}
-]}'
-```
-
 ### --set key=value（通用）
 
 `--set` 是普通 flag 的**替代写法**，只影响**顶层参数**：`--set key=value` 等价于 `--key value`。适合在脚本里用统一的 key=value 语法，或通过 dot-path 写嵌套顶层对象。值自动类型推断（int / float / bool / string）。
@@ -527,14 +518,49 @@ meegle mywork todo --set action=this_week --set page_num=1
 
 `--set` 只写**顶层参数**，**不会**写到工作项的 `fields[]`。写 `fields[]` 请用 `--params '{"fields":[...]}'`（见下）。
 
-### --params JSON（兜底）
+### --params JSON
 
-所有命令都支持 `--params` 传入完整 JSON 参数：
+`--params` 接收一个 JSON 对象，**每个顶层 key 都会作为 CLI flag 合并进来**。
+顶层 key 必须是当前命令的合法 flag —— 它不是一份自由结构的载荷。
+
+```bash
+# 下面两条等价：
+meegle workitem get --work-item-id 12345 --project-key PROJ
+meegle workitem get --params '{"work_item_id":12345,"project_key":"PROJ"}'
+```
+
+什么时候用 `--params`：
+
+- 值是嵌套对象或数组（`fields[]`、`schedule{}`），直接写 flag 太别扭
+- 想一次性批量传多个参数，或者从文件加载载荷（见下方 `@file.json`）
 
 ```bash
 meegle workitem create --project-key PROJ --work-item-type story \
   --params '{"fields":[{"field_key":"name","field_value":"标题"}]}'
 ```
+
+#### 常见误用：不是所有名字都是顶层 flag
+
+有些**看起来像**顶层字段的值，其实是工作项的字段值，必须包在 `fields[]`
+里，而不是放在顶层。比如 `workitem update` 时，`priority` 属于工作项字段，
+不是命令的 flag：
+
+```bash
+# ❌ "priority" 不是 workitem update 的合法 flag —— CLI 会在 stderr 输出 warning，后端忽略
+meegle workitem update --work-item-id 12345 --params '{"priority":"P1"}'
+
+# ✓ 字段值要包在 fields[] 里
+meegle workitem update --work-item-id 12345 \
+  --params '{"fields":[{"field_key":"priority","field_value":"P1"}]}'
+```
+
+不在工具声明 flag 列表里的顶层 key，在 `--dry-run` 输出里会以
+`validation.unknown_params` 列出，运行时则会向 stderr 打一行
+warning。它们仍然会被原样转发给后端（防止本地工具 schema 缓存陈旧
+误判，需要时用 `--refresh` 刷新）。
+
+通过 `meegle workitem meta-fields --project-key PK --work-item-type TK`
+查询某种工作项类型下合法的 `field_key`。
 
 #### 从文件读取（`@file.json`）
 
@@ -726,7 +752,7 @@ export MEEGLE_USER_AGENT=ci-runner  # 可选；追加到 User-Agent，优先级�
 meegle workitem get --work-item-id 123
 ```
 
-任一变量可以单独设置。走这个路径时 CLI 不访问 keychain，401 错误不会自动 refresh，由调用方自行轮转。
+任一变量可以单独设置。当 `MEEGLE_USER_ACCESS_TOKEN` 设置时，CLI 不访问 keychain，401 错误不会自动 refresh，由调用方自行轮转。仅设置 `MEEGLE_HOST`（不带 token）时仍走 keychain 中存储的凭证。
 
 ### 自定义 Auth Header
 

--- a/internal/products/meegle/dynamic/mapper.go
+++ b/internal/products/meegle/dynamic/mapper.go
@@ -44,11 +44,12 @@ var fallbackTable = map[string]fallbackEntry{
 	// mywork (1)
 	"list_todo": {resource: "mywork", method: "todo", description: "List my work items by action (todo/done/overdue/this_week)"},
 
-	// view (4)
-	"create_fixed_view":    {resource: "view", method: "create-fixed", description: "Create fixed view"},
-	"get_view_detail":      {resource: "view", method: "get", description: "List work items under a view by view ID"},
-	"update_fixed_view":    {resource: "view", method: "update-fixed", description: "Update fixed view"},
-	"search_view_by_title": {resource: "view", method: "search", description: "Search views by title to resolve view_id"},
+	// view (5)
+	"create_fixed_view":                 {resource: "view", method: "create-fixed", description: "Create fixed view"},
+	"get_view_detail":                   {resource: "view", method: "get", description: "List work items under a view by view ID"},
+	"update_fixed_view":                 {resource: "view", method: "update-fixed", description: "Update fixed view"},
+	"search_view_by_title":              {resource: "view", method: "search", description: "Search views by title to resolve view_id"},
+	"list_multi_project_view_workitems": {resource: "view", method: "list-multi-project-workitems", description: "List work items the caller can access under a multi-project (panoramic) view; pass --view-id from a multiProjectView URL"},
 
 	// chart (2)
 	"get_chart_detail": {resource: "chart", method: "get", description: "Get chart details"},

--- a/internal/products/meegle/dynamic/mapper_test.go
+++ b/internal/products/meegle/dynamic/mapper_test.go
@@ -60,11 +60,12 @@ var fallbackTests = []struct {
 	{"list_node_field_config", "workflow", "meta-node-fields"},
 	// mywork (1)
 	{"list_todo", "mywork", "todo"},
-	// view (4)
+	// view (5)
 	{"create_fixed_view", "view", "create-fixed"},
 	{"get_view_detail", "view", "get"},
 	{"update_fixed_view", "view", "update-fixed"},
 	{"search_view_by_title", "view", "search"},
+	{"list_multi_project_view_workitems", "view", "list-multi-project-workitems"},
 	// chart (2)
 	{"get_chart_detail", "chart", "get"},
 	{"list_charts", "chart", "list"},
@@ -95,8 +96,8 @@ func TestFallbackTable(t *testing.T) {
 }
 
 func TestFallbackTableCount(t *testing.T) {
-	if len(fallbackTable) != 36 {
-		t.Errorf("expected 36 fallback entries, got %d", len(fallbackTable))
+	if len(fallbackTable) != 37 {
+		t.Errorf("expected 37 fallback entries, got %d", len(fallbackTable))
 	}
 }
 

--- a/internal/products/meegle/params_validate.go
+++ b/internal/products/meegle/params_validate.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package meegle
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/larksuite/meegle-cli/pkg/framework/pipeline"
+)
+
+// findUnknownParams returns sorted snake_case keys in snakeParams that are
+// not declared as flags of the current MCP tool. Returns nil when no schema
+// info is available (defensive: avoid false positives on malformed cache).
+func findUnknownParams(state *pipeline.PipelineContext, snakeParams map[string]any) []string {
+	if state == nil || state.Parsed == nil || state.Parsed.Node == nil {
+		return nil
+	}
+	raw := state.Parsed.Node.Meta.Tags["mcp_param_types"]
+	if raw == "" {
+		return nil
+	}
+	var paramTypes map[string]string
+	if err := json.Unmarshal([]byte(raw), &paramTypes); err != nil {
+		return nil
+	}
+	valid := make(map[string]struct{}, len(paramTypes))
+	for kebab := range paramTypes {
+		valid[strings.ReplaceAll(kebab, "-", "_")] = struct{}{}
+	}
+	// Fixed params injected at registry level are also legitimate keys.
+	if rawFixed := state.Parsed.Node.Meta.Tags["mcp_fixed_params"]; rawFixed != "" {
+		var fixed map[string]any
+		if err := json.Unmarshal([]byte(rawFixed), &fixed); err == nil {
+			for k := range fixed {
+				valid[k] = struct{}{}
+			}
+		}
+	}
+	var unknown []string
+	for k := range snakeParams {
+		if _, ok := valid[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+// formatUnknownParamsWarning composes a single-line stderr-friendly warning.
+// Returns "" when the unknown list is empty so callers can branch cheaply.
+func formatUnknownParamsWarning(toolName string, unknown []string) string {
+	if len(unknown) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"warning: unknown argument(s) for %s: %s — sent to backend as-is and likely ignored. See --help for valid flags.",
+		toolName, strings.Join(unknown, ", "),
+	)
+}

--- a/internal/products/meegle/params_validate_test.go
+++ b/internal/products/meegle/params_validate_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package meegle
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/meegle-cli/pkg/framework/pipeline"
+	"github.com/larksuite/meegle-cli/pkg/framework/registry"
+	"github.com/larksuite/meegle-cli/pkg/framework/router"
+)
+
+func newValidateState(paramTypesJSON, fixedParamsJSON string) *pipeline.PipelineContext {
+	tags := map[string]string{}
+	if paramTypesJSON != "" {
+		tags["mcp_param_types"] = paramTypesJSON
+	}
+	if fixedParamsJSON != "" {
+		tags["mcp_fixed_params"] = fixedParamsJSON
+	}
+	return &pipeline.PipelineContext{
+		Parsed: &router.ParsedCommand{
+			Node: &registry.CommandNode{Meta: registry.NodeMeta{Tags: tags}},
+		},
+	}
+}
+
+func TestFindUnknownParams_AllValid(t *testing.T) {
+	state := newValidateState(`{"work-item-id":"string","project-key":"string"}`, "")
+	params := map[string]any{"work_item_id": "1", "project_key": "p-1"}
+	if got := findUnknownParams(state, params); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestFindUnknownParams_OneUnknown(t *testing.T) {
+	state := newValidateState(`{"work-item-id":"string","project-key":"string"}`, "")
+	params := map[string]any{"work_item_id": "1", "name": "x"}
+	want := []string{"name"}
+	if got := findUnknownParams(state, params); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestFindUnknownParams_MultipleUnknownSorted(t *testing.T) {
+	state := newValidateState(`{"work-item-id":"string"}`, "")
+	params := map[string]any{"work_item_id": "1", "priority": "P1", "assignee": "u-1"}
+	want := []string{"assignee", "priority"}
+	if got := findUnknownParams(state, params); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestFindUnknownParams_NoSchemaSkips(t *testing.T) {
+	// Defensive: missing schema must NOT trigger false-positive warnings.
+	state := newValidateState("", "")
+	params := map[string]any{"anything": "goes"}
+	if got := findUnknownParams(state, params); got != nil {
+		t.Errorf("expected nil when schema absent, got %v", got)
+	}
+}
+
+func TestFindUnknownParams_MalformedSchemaSkips(t *testing.T) {
+	state := newValidateState(`not-json`, "")
+	params := map[string]any{"anything": "goes"}
+	if got := findUnknownParams(state, params); got != nil {
+		t.Errorf("expected nil for malformed schema, got %v", got)
+	}
+}
+
+func TestFindUnknownParams_FixedParamsAreValid(t *testing.T) {
+	// mcp_fixed_params keys are injected at registry level (sugar / batch
+	// commands) — they must not be flagged as unknown.
+	state := newValidateState(`{"work-item-id":"string"}`, `{"action":"this_week"}`)
+	params := map[string]any{"work_item_id": "1", "action": "this_week"}
+	if got := findUnknownParams(state, params); got != nil {
+		t.Errorf("fixed params should be valid, got %v", got)
+	}
+}
+
+func TestFindUnknownParams_NilState(t *testing.T) {
+	if got := findUnknownParams(nil, map[string]any{"x": 1}); got != nil {
+		t.Errorf("expected nil for nil state, got %v", got)
+	}
+}
+
+func TestFormatUnknownParamsWarning_Empty(t *testing.T) {
+	if got := formatUnknownParamsWarning("update_workitem", nil); got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestFormatUnknownParamsWarning_Single(t *testing.T) {
+	got := formatUnknownParamsWarning("update_node_subtask", []string{"name"})
+	for _, want := range []string{"warning", "update_node_subtask", "name", "--help"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning missing %q, got %q", want, got)
+		}
+	}
+}
+
+func TestFormatUnknownParamsWarning_Multiple(t *testing.T) {
+	got := formatUnknownParamsWarning("tool", []string{"a", "b"})
+	if !strings.Contains(got, "a, b") {
+		t.Errorf("expected comma-separated keys, got %q", got)
+	}
+}

--- a/internal/products/meegle/pipeline.go
+++ b/internal/products/meegle/pipeline.go
@@ -261,19 +261,27 @@ func (s *McpExecutorStep) Execute(ctx context.Context, state *pipeline.PipelineC
 		}
 	}
 
+	unknownParams := findUnknownParams(state, snakeParams)
+
 	// --dry-run: return the payload that would be sent to the backend without
 	// performing the network call. This lets users preview the result of
 	// --params/--set after type coercion, and works offline (no auth required
 	// — SessionStep also short-circuits on dry-run).
 	if isDryRunFlag(state.Parsed) {
-		state.Result = &executor.RawResult{
-			Data: map[string]any{
-				"tool":    toolName,
-				"params":  snakeParams,
-				"dry_run": true,
-			},
+		payload := map[string]any{
+			"tool":    toolName,
+			"params":  snakeParams,
+			"dry_run": true,
 		}
+		if len(unknownParams) > 0 {
+			payload["validation"] = map[string]any{"unknown_params": unknownParams}
+		}
+		state.Result = &executor.RawResult{Data: payload}
 		return nil
+	}
+
+	if msg := formatUnknownParamsWarning(toolName, unknownParams); msg != "" {
+		fmt.Fprintln(os.Stderr, msg)
 	}
 
 	client := newMcpClientFromState(state)

--- a/internal/products/meegle/pipeline_test.go
+++ b/internal/products/meegle/pipeline_test.go
@@ -570,6 +570,87 @@ func TestMcpExecutorStep_DryRunSkipsBackend(t *testing.T) {
 	}
 }
 
+// Dry-run must surface unknown top-level params as a `validation.unknown_params`
+// list so users can spot ignored arguments without doing a live round-trip.
+// Drives the user-facing case where `--params '{"name":"..."}'` looks correct
+// in the dry-run output but is silently dropped by the backend.
+func TestMcpExecutorStep_DryRunIncludesUnknownParamsValidation(t *testing.T) {
+	step := &McpExecutorStep{}
+	tagsJSON := `{"work-item-id":"string","project-key":"string"}`
+	state := &pipeline.PipelineContext{
+		Parsed: &router.ParsedCommand{
+			FullPath: []string{"workitem", "update"},
+			Node: &registry.CommandNode{
+				HandlerRef: "update_workitem_fields",
+				Meta:       registry.NodeMeta{Tags: map[string]string{"mcp_param_types": tagsJSON}},
+			},
+			Flags: map[string]any{
+				"dry-run":      true,
+				"work-item-id": "1",
+				"project-key":  "p-1",
+				"name":         "stray",
+			},
+			ExplicitFlags: map[string]any{
+				"dry-run":      true,
+				"work-item-id": "1",
+				"project-key":  "p-1",
+				"name":         "stray",
+			},
+		},
+	}
+	if err := step.Execute(context.Background(), state); err != nil {
+		t.Fatalf("dry-run execute: %v", err)
+	}
+	data, ok := state.Result.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T", state.Result.Data)
+	}
+	validation, ok := data["validation"].(map[string]any)
+	if !ok {
+		t.Fatalf("validation not a map: %#v", data["validation"])
+	}
+	unknown, ok := validation["unknown_params"].([]string)
+	if !ok {
+		t.Fatalf("unknown_params not a []string: %#v", validation["unknown_params"])
+	}
+	if len(unknown) != 1 || unknown[0] != "name" {
+		t.Errorf("unknown_params = %v, want [name]", unknown)
+	}
+}
+
+// All-valid dry-run must NOT add a validation field — preserves backward
+// compatibility for callers that parse dry-run JSON output.
+func TestMcpExecutorStep_DryRunNoValidationWhenAllParamsValid(t *testing.T) {
+	step := &McpExecutorStep{}
+	tagsJSON := `{"work-item-id":"string","project-key":"string"}`
+	state := &pipeline.PipelineContext{
+		Parsed: &router.ParsedCommand{
+			FullPath: []string{"workitem", "update"},
+			Node: &registry.CommandNode{
+				HandlerRef: "update_workitem_fields",
+				Meta:       registry.NodeMeta{Tags: map[string]string{"mcp_param_types": tagsJSON}},
+			},
+			Flags: map[string]any{
+				"dry-run":      true,
+				"work-item-id": "1",
+				"project-key":  "p-1",
+			},
+			ExplicitFlags: map[string]any{
+				"dry-run":      true,
+				"work-item-id": "1",
+				"project-key":  "p-1",
+			},
+		},
+	}
+	if err := step.Execute(context.Background(), state); err != nil {
+		t.Fatalf("dry-run execute: %v", err)
+	}
+	data := state.Result.Data.(map[string]any)
+	if _, present := data["validation"]; present {
+		t.Errorf("validation should be absent when no unknown params, got %#v", data["validation"])
+	}
+}
+
 // Regression: SessionStep must not require auth when --dry-run is set, so
 // dry-run works offline (no token) and surfaces errors locally. setupTestDir
 // isolates the config dir to a fresh tempdir so the user's real profile

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",

--- a/pkg/framework/registry/builtin_flags.go
+++ b/pkg/framework/registry/builtin_flags.go
@@ -5,7 +5,7 @@ package registry
 
 var BuiltinFlags = []FlagDef{
 	{Name: "set", Type: FlagTypeStringSlice, Description: "Set nested parameters using key=value, supports dot path."},
-	{Name: "params", Short: "P", Type: FlagTypeString, Description: "JSON parameters merged before --set."},
+	{Name: "params", Short: "P", Type: FlagTypeString, Description: "JSON object whose top-level keys are merged as CLI flags."},
 	{Name: "dry-run", Type: FlagTypeBool, Description: "Render the normalized request without executing the backend."},
 	{Name: "format", Short: "o", Type: FlagTypeString, Enum: []string{"json", "ndjson", "table"}, Description: "Output format. Default json."},
 	{Name: "select", Type: FlagTypeString, Description: "Field projection; comma-separated dot paths, e.g. id,creator.email."},

--- a/skills/meegle/references/mql-syntax.md
+++ b/skills/meegle/references/mql-syntax.md
@@ -214,7 +214,7 @@ array_contains(participate_roles(), 'RD', 'QA')
 
   **排期/节点时间子字段**：
   - 节点排期：`get_node_attribute('节点名','__排期_开始时间')`、`get_node_attribute('节点名','__排期_结束时间')`
-  - 节点时间：`get_node_attribute('节点名','__节点时间_开始时间')`、`get_node_attribute('节点名','__节点时间_完成时间')`
+  - 节点时间：`get_node_attribute('节点名','__节点时间_开始时间')`、`get_node_attribute('节点名','__节点时间_结束时间')`
 
   ```sql
   -- 开始节点排期在过去 30 天内

--- a/skills/meegle/references/view.md
+++ b/skills/meegle/references/view.md
@@ -29,3 +29,12 @@
 | --project-key | string | 是 | 空间 key |
 | --view-id | string | 是 | 视图 ID |
 | --work-item-type | string | 是 | 工作项类型 |
+
+## view list-multi-project-workitems
+查看全景视图（multiProjectView）下当前用户有权限的工作项列表。全景视图的链接上带有 `multiProjectView` 关键字，可从中提取 `view_id`。
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| --project-key | string | 是 | 空间 key |
+| --view-id | string | 是 | 全景视图 ID |
+| --page-num | number | 否 | 分页页码，每页 50 条，从 1 开始 |


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.