### PR TITLE
release: v1.0.3 — fix User-Agent version reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.3] - 2026-05-18
+
+### Fixed
+
+- `User-Agent` now reports the semantic version injected via `-ldflags "-X main.version=..."` (e.g. `meegle-cli/1.0.3`) instead of Go's `debug.ReadBuildInfo()` pseudo-version. Previously backends observed UAs like `meegle-cli/v0.0.0-20260417123425-9973fd9cecc4+dirty` whenever a build was made off a non-tagged commit or with uncommitted files in the worktree, making per-version traffic attribution unreliable on the server-side dashboard. The fix landed on `main` after the v1.0.2 release commit was tagged and published, so the CHANGELOG entry was retroactively moved out of the v1.0.2 section to match what npm actually shipped
+
 ## [v1.0.2] - 2026-05-14
 
 ### Added

--- a/cmd/meegle/main.go
+++ b/cmd/meegle/main.go
@@ -12,6 +12,7 @@ import (
 	productmeegle "github.com/larksuite/meegle-cli/internal/products/meegle"
 	"github.com/larksuite/meegle-cli/internal/products/meegle/commands"
 	meerrors "github.com/larksuite/meegle-cli/internal/products/meegle/errors"
+	"github.com/larksuite/meegle-cli/internal/products/meegle/mcpclient"
 	frameworkerrors "github.com/larksuite/meegle-cli/pkg/framework/errors"
 	"github.com/larksuite/meegle-cli/pkg/runtime/cliapp"
 )
@@ -19,6 +20,11 @@ import (
 var version = "dev"
 
 func main() {
+	// Propagate the ldflags-injected version into the User-Agent. Without this
+	// the UA falls back to Go's debug.ReadBuildInfo() pseudo-version, which is
+	// what backends observe today (e.g. "meegle-cli/v0.0.0-…+dirty").
+	mcpclient.SetVersion(version)
+
 	// Resolve mapped commands for the inspect command
 	mappedCommands := productmeegle.ResolveMappedCommands()
 

--- a/internal/products/meegle/mcpclient/options.go
+++ b/internal/products/meegle/mcpclient/options.go
@@ -46,10 +46,37 @@ func WithUserAgent(ua string) Option {
 	}
 }
 
-// DefaultUserAgent returns "meegle-cli" with module version appended if available.
-// e.g. "meegle-cli" or "meegle-cli/0.1.0"
+// injectedVersion is the version string set by main packages via SetVersion.
+// When non-empty, DefaultUserAgent prefers it over debug.ReadBuildInfo().
+// Reason: the npm release build injects the semantic version through
+// `-ldflags "-X main.version=..."`, and that value is the one product/users
+// identify releases by — not Go's pseudo-version (which carries commit hashes
+// and a "+dirty" suffix when the build tree has uncommitted files).
+var injectedVersion string
+
+// SetVersion records the semantic version reported in User-Agent. Main
+// packages should call this before constructing the CLI app so the first
+// outbound request already carries the correct UA. Empty / "dev" inputs are
+// ignored to preserve the debug.ReadBuildInfo() fallback in local builds.
+func SetVersion(v string) {
+	if v == "" || v == "dev" {
+		return
+	}
+	injectedVersion = v
+}
+
+// DefaultUserAgent returns "meegle-cli" with version appended if available.
+// e.g. "meegle-cli" or "meegle-cli/1.0.1"
+//
+// Version source priority:
+//  1. injectedVersion (set via SetVersion, populated from `-ldflags "-X main.version=..."`)
+//  2. debug.ReadBuildInfo().Main.Version (Go module version — SDK consumers
+//     and local `go build` invocations that bypass the Makefile)
 func DefaultUserAgent() string {
 	base := "meegle-cli"
+	if injectedVersion != "" {
+		return base + "/" + injectedVersion
+	}
 	if info, ok := debug.ReadBuildInfo(); ok {
 		v := info.Main.Version
 		if v != "" && v != "(devel)" {

--- a/internal/products/meegle/mcpclient/options_test.go
+++ b/internal/products/meegle/mcpclient/options_test.go
@@ -39,3 +39,38 @@ func TestBuildUserAgent(t *testing.T) {
 		})
 	}
 }
+
+// SetVersion must take precedence over debug.ReadBuildInfo() so the UA
+// reports the semantic version injected via ldflags rather than Go's
+// pseudo-version (which leaks "+dirty" suffixes in CI builds).
+func TestSetVersionOverridesBuildInfo(t *testing.T) {
+	saved := injectedVersion
+	t.Cleanup(func() { injectedVersion = saved })
+
+	injectedVersion = ""
+	SetVersion("1.0.1")
+	if got := DefaultUserAgent(); got != "meegle-cli/1.0.1" {
+		t.Errorf("after SetVersion(1.0.1): got %q, want %q", got, "meegle-cli/1.0.1")
+	}
+
+	// BuildUserAgent must compose on top of the injected version.
+	if got := BuildUserAgent("mira"); got != "meegle-cli/1.0.1 mira" {
+		t.Errorf("BuildUserAgent with injected version: got %q, want %q", got, "meegle-cli/1.0.1 mira")
+	}
+}
+
+// SetVersion must ignore empty / "dev" inputs so local `go build` invocations
+// (which leave `version = "dev"` unchanged) keep the debug.ReadBuildInfo()
+// fallback instead of reporting "meegle-cli/dev".
+func TestSetVersionIgnoresPlaceholders(t *testing.T) {
+	saved := injectedVersion
+	t.Cleanup(func() { injectedVersion = saved })
+
+	for _, v := range []string{"", "dev"} {
+		injectedVersion = ""
+		SetVersion(v)
+		if injectedVersion != "" {
+			t.Errorf("SetVersion(%q) set injectedVersion to %q, want empty", v, injectedVersion)
+		}
+	}
+}

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",

--- a/skills/meegle/references/auth-guard.md
+++ b/skills/meegle/references/auth-guard.md
@@ -5,7 +5,7 @@
 - **主动登录**：用户说"登录 Meegle"、"连接飞书项目"、"login meegle"等。
 - **被动拦截**：用户请求任何 Meegle 业务操作（查询待办、查工作项、创建任务等），优先执行 Auth Guard。
 - **URL 触发**：用户发送了飞书项目/Meegle URL。处理流程：
-  1. 先调 `url decode` 拿到结构化字段（`url_kind`、`host`、`simple_name`、`work_item_id` 等）。**禁止**自己从 URL 截取路径段作参数。字段含义与 kind 分支见 [url-kinds.md](./url-kinds.md)。
+  1. 先调 `url decode` 拿到结构化字段（`url_kind`、`host`、`simple_name`、`work_item_id` 等）。**禁止**自己从 URL 截取路径段作参数。字段含义与 kind 分支见 [url-kinds.md](url-kinds.md)。
   2. 保存 `$host` = response.host、`$url_kind`、`$simple_name`、`$work_item_id`。
   3. 执行 Auth Guard（下面的 STEP 1 起）。
   4. 登录成功后按 `$url_kind` 分支：

--- a/skills/meegle/references/sop-create-workitem.md
+++ b/skills/meegle/references/sop-create-workitem.md
@@ -14,7 +14,7 @@
 - **空间名**：哪个项目空间
 - **工作项类型**：需求 / 任务 / 缺陷 / 其他
 - **字段值**：标题、优先级、负责人、描述等
-- **URL**（如有）：先调 `url decode` 解析。`url_kind` 非 `workitem_create` / `workitem_detail` 时按 [url-kinds.md](../references/url-kinds.md) 拒绝或追问；命中则用返回的 `simple_name` 取代空间名探测，`work_item_type` 取代类型探测。**禁止**自己从 URL 截取路径段作参数。
+- **URL**（如有）：先调 `url decode` 解析。`url_kind` 非 `workitem_create` / `workitem_detail` 时按 [url-kinds.md](url-kinds.md) 拒绝或追问；命中则用返回的 `simple_name` 取代空间名探测，`work_item_type` 取代类型探测。**禁止**自己从 URL 截取路径段作参数。
 
 
 ### STEP 2 — 确认空间和类型

--- a/skills/meegle/references/sop-transition-node.md
+++ b/skills/meegle/references/sop-transition-node.md
@@ -26,7 +26,7 @@
 ### STEP 1 — 定位工作项
 
 从用户输入中提取 work_item_id 和 project_key：
-- 用户给了 **URL** → 先调 `url decode`。只有 `url_kind == workitem_detail` 才能进入本 SOP；其他 kind 按 [url-kinds.md](../references/url-kinds.md) 拒绝或追问
+- 用户给了 **URL** → 先调 `url decode`。只有 `url_kind == workitem_detail` 才能进入本 SOP；其他 kind 按 [url-kinds.md](url-kinds.md) 拒绝或追问
 - 用户给了 **ID** → 需同时确定 project_key
 - 信息不足时才追问
 

--- a/skills/meegle/references/sop-transition-state.md
+++ b/skills/meegle/references/sop-transition-state.md
@@ -15,7 +15,7 @@
 **并行执行**：
 
 1. **定位工作项**：从用户输入中提取 `work_item_id`、`project_key`、`work_item_type`。
-   - **URL 解析**：用户给了链接则先调 `url decode`。只有 `url_kind == workitem_detail` 才能进入本 SOP；其他 kind 按 [url-kinds.md](../references/url-kinds.md) 拒绝或追问。decode 返回的 `simple_name` 必须再调 `project search` 转为权威 `project_key`（同名空间可能有多个无权限）。**禁止**自己从 URL 截取路径段作参数。
+   - **URL 解析**：用户给了链接则先调 `url decode`。只有 `url_kind == workitem_detail` 才能进入本 SOP；其他 kind 按 [url-kinds.md](url-kinds.md) 拒绝或追问。decode 返回的 `simple_name` 必须再调 `project search` 转为权威 `project_key`（同名空间可能有多个无权限）。**禁止**自己从 URL 截取路径段作参数。
    - **ID 类型**：传给任何工具的 `work_item_id` 必须是 **字符串（String）**。
    - 信息不足才追问。
 2. **获取当前用户**：调用 `user search`，入参 `["current_login_user()"]` 拿到当前用户的 `user_key`（下一步必填）。

--- a/skills/meegle/references/sop-update-workitem.md
+++ b/skills/meegle/references/sop-update-workitem.md
@@ -14,7 +14,7 @@
 - **目标工作项** — URL、工作项 ID 或名称
 - **修改内容** — 哪些字段要改成什么值
 
-> **URL 处理**：用户给了 URL 必须先调 `url decode`。只有 `url_kind == workitem_detail` 才能进入本 SOP；其他 kind 按 [url-kinds.md](../references/url-kinds.md) 拒绝或追问。拿到 `simple_name` 和 `work_item_id` 后，必须再调 `project search` 把 `simple_name` 转为权威 `project_key`（同名空间可能有多个）。**禁止**自己从 URL 截取路径段作参数。`work_item_id` 参数必须是字符串类型。
+> **URL 处理**：用户给了 URL 必须先调 `url decode`。只有 `url_kind == workitem_detail` 才能进入本 SOP；其他 kind 按 [url-kinds.md](url-kinds.md) 拒绝或追问。拿到 `simple_name` 和 `work_item_id` 后，必须再调 `project search` 把 `simple_name` 转为权威 `project_key`（同名空间可能有多个）。**禁止**自己从 URL 截取路径段作参数。`work_item_id` 参数必须是字符串类型。
 
 🚨 **获取工作项类型（极重要）**：后续所有查询（字段配置、角色配置等）都强依赖 `work_item_type`。如果用户没有明确告知类型，**必须先调 `workitem get` 获取该实例的真实 `work_item_type`（返回体中的 `work_item_type.key`）**，绝不能猜测为 story 或 issue。
 


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.