### PR TITLE
fix: object-typed MCP params (e.g. subtask schedule) now serialize as JSON objects (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.4] - 2026-05-19
+
+### Fixed
+
+- Object-typed parameters discovered from the MCP tool schema (e.g. `subtask update --schedule`, `workflow update-node --schedule`) are now JSON-decoded into a real object before being sent to the backend; previously the raw JSON string was forwarded verbatim, so the server silently dropped the field and downstream attributes (e.g. `start_date` / `end_date` on a subtask schedule) ended up empty. Malformed JSON is still passed through unchanged so the backend can surface a clear validation error instead of a no-op (issue #14)
+
 ## [v1.0.3] - 2026-05-18
 
 ### Fixed

--- a/internal/products/meegle/pipeline.go
+++ b/internal/products/meegle/pipeline.go
@@ -474,6 +474,23 @@ func coerceValue(v any, mcpType string, itemsType string) any {
 		return v
 	case "array":
 		return coerceArray(v, itemsType)
+	case "object":
+		// Object-typed MCP params are surfaced as `--flag string` (see
+		// registry.mapParamType) and must be JSON-decoded before reaching
+		// the backend; otherwise the server receives a string literal and
+		// silently drops the field (e.g. issue#14 `subtask update --schedule`).
+		// On parse failure keep the raw string so the backend can surface
+		// a clearer error than a no-op.
+		if s, ok := v.(string); ok && s != "" {
+			trimmed := strings.TrimSpace(s)
+			if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+				var parsed any
+				if err := json.Unmarshal([]byte(trimmed), &parsed); err == nil {
+					return parsed
+				}
+			}
+		}
+		return v
 	default:
 		return v
 	}

--- a/internal/products/meegle/pipeline_test.go
+++ b/internal/products/meegle/pipeline_test.go
@@ -875,6 +875,53 @@ func TestCoerceArray_BrokenJSONKeptAsString(t *testing.T) {
 	}
 }
 
+// --- coerceValue object-type handling (issue#14) -------------------------
+
+func TestCoerceValue_ObjectJSONStringDecoded(t *testing.T) {
+	got := coerceValue(`{"start_date":"2026-05-19","end_date":"2026-05-20"}`, "object", "")
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("type = %T, want map[string]any (got %#v)", got, got)
+	}
+	if m["start_date"] != "2026-05-19" || m["end_date"] != "2026-05-20" {
+		t.Fatalf("decoded map = %#v", m)
+	}
+}
+
+func TestCoerceValue_ObjectJSONArrayDecoded(t *testing.T) {
+	got := coerceValue(`[1,2,3]`, "object", "")
+	arr, ok := got.([]any)
+	if !ok {
+		t.Fatalf("type = %T, want []any", got)
+	}
+	if len(arr) != 3 {
+		t.Fatalf("len = %d, want 3: %#v", len(arr), arr)
+	}
+}
+
+func TestCoerceValue_ObjectBrokenJSONKeptAsString(t *testing.T) {
+	got := coerceValue(`{not json`, "object", "")
+	if got != `{not json` {
+		t.Fatalf("got = %#v, want raw string", got)
+	}
+}
+
+func TestCoerceValue_ObjectEmptyStringPassesThrough(t *testing.T) {
+	got := coerceValue("", "object", "")
+	if got != "" {
+		t.Fatalf("got = %#v, want empty string", got)
+	}
+}
+
+func TestCoerceValue_ObjectNonStringPassesThrough(t *testing.T) {
+	in := map[string]any{"already": "object"}
+	got := coerceValue(in, "object", "")
+	m, ok := got.(map[string]any)
+	if !ok || m["already"] != "object" {
+		t.Fatalf("got = %#v", got)
+	}
+}
+
 func TestNewPipelineFactory(t *testing.T) {
 	factory := newPipelineFactory(NewDynamicRegistrySetup(nil, nil))
 	pipe, err := factory(cliapp.Config{})

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.