### PR TITLE
fix: validate auth status against server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.6] - 2026-05-28
+
+### Changed
+
+- `auth status` now issues a lightweight `tools/list` call to validate the token against the server, instead of only checking whether a token string is present locally. Cron / CI preflights that previously saw `authenticated: true` followed by an immediate `401` on the next business call now get the correct verdict up front. JSON output gains a `reason` field on failure (`no local token` / `token rejected by server` / `server unreachable: <err>`). A new exit code `2` indicates the server was unreachable (network, timeout, 5xx) — distinct from exit `1` which still covers missing or rejected tokens. There is no opt-out flag: offline status inspection is intentionally no longer supported.
+
 ## [v1.0.5] - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ The agent consults the skill, picks the right `meegle` commands, and runs them f
 |---------|-------------|
 | `auth login` | Log in (browser or `--device-code`) |
 | `auth logout` | Log out |
-| `auth status` | View login status |
+| `auth status` | View login status (validates the token against the server) |
 
 ### config — Configuration
 
@@ -757,11 +757,28 @@ The terminal displays a QR code and authorization code. Scan with your phone to 
 ### Other Auth Commands
 
 ```bash
-# Check login status
+# Check login status (issues a lightweight tools/list call to validate the
+# token against the server — safe to use as a cron preflight)
 meegle auth status
 
 # Log out
 meegle auth logout
+```
+
+`auth status` exit codes and `reason` field let scripts (cron jobs, CI
+preflights) react correctly without having to parse human text:
+
+| Exit | `reason` | Meaning | Recommended action |
+|------|----------|---------|--------------------|
+| 0    | —        | Token is present locally and accepted by the server | Proceed |
+| 1    | `no local token` | No token stored | Run `meegle auth login` |
+| 1    | `token rejected by server` | Token expired or revoked; refresh exhausted | Run `meegle auth login` |
+| 2    | `server unreachable: <err>` | Network, timeout, or 5xx — the call itself failed | Retry later; do not re-login |
+
+JSON output example (`auth status --format json`) on a rejected token:
+
+```json
+{"authenticated": false, "host": "meegle.com", "reason": "token rejected by server"}
 ```
 
 ## Configuration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -289,7 +289,7 @@ Agent 会参考 skill，自动选择合适的 `meegle` 命令执行。配合 `--
 |------|------|
 | `auth login` | 登录（浏览器或 `--device-code`） |
 | `auth logout` | 登出 |
-| `auth status` | 查看登录状态 |
+| `auth status` | 查看登录状态（会向服务端发一次校验请求，确认 token 真实可用） |
 
 ### config — 配置域
 
@@ -734,11 +734,28 @@ meegle auth login --device-code
 ### 其他认证命令
 
 ```bash
-# 查看登录状态
+# 查看登录状态（会向服务端发一次轻量 tools/list 调用校验 token，可作为
+# cron 任务的 preflight）
 meegle auth status
 
 # 登出
 meegle auth logout
+```
+
+`auth status` 退出码与 `reason` 字段配合，让 cron / CI preflight 脚本
+不用解析人类可读文本即可分支处理：
+
+| 退出码 | `reason` | 含义 | 建议动作 |
+|--------|----------|------|----------|
+| 0      | —        | 本地有 token 且服务端校验通过 | 继续执行 |
+| 1      | `no local token` | 本地无 token | 执行 `meegle auth login` |
+| 1      | `token rejected by server` | token 已过期或被撤销（refresh 也救不回来） | 执行 `meegle auth login` |
+| 2      | `server unreachable: <err>` | 网络、超时、5xx —— 调用本身失败 | 稍后重试，不要重新登录 |
+
+JSON 输出示例（`auth status --format json`），token 被拒：
+
+```json
+{"authenticated": false, "host": "meegle.com", "reason": "token rejected by server"}
 ```
 
 ## 配置

--- a/internal/products/meegle/app.go
+++ b/internal/products/meegle/app.go
@@ -274,6 +274,20 @@ func buildMcpClient(cfg MeegleConfig, profileName string) (*mcpclient.Client, Re
 		// diagnostics) even though no client could be built.
 		return nil, ident
 	}
+	return NewMCPClientFromIdentity(ident), ident
+}
+
+// NewMCPClientFromIdentity builds an MCP client directly from an already
+// resolved identity. Callers that have already resolved the identity (e.g.
+// per-command paths that read it from ResolveIdentity to inspect Source /
+// Token before deciding what to do) reuse this to avoid the redundant
+// resolution that buildMcpClient performs internally.
+//
+// Requires ident.Host and ident.Token to be non-empty; returns nil otherwise.
+func NewMCPClientFromIdentity(ident ResolvedIdentity) *mcpclient.Client {
+	if ident.Host == "" || ident.Token == "" {
+		return nil
+	}
 
 	baseURL := GetServerURL(MeegleConfig{Host: ident.Host})
 	httpHeaders := make(http.Header)
@@ -301,5 +315,5 @@ func buildMcpClient(cfg MeegleConfig, profileName string) (*mcpclient.Client, Re
 		token := ident.Token
 		opts = append(opts, mcpclient.WithToken(func() (string, error) { return token, nil }))
 	}
-	return mcpclient.New(baseURL, opts...), ident
+	return mcpclient.New(baseURL, opts...)
 }

--- a/internal/products/meegle/batch.go
+++ b/internal/products/meegle/batch.go
@@ -312,7 +312,7 @@ func (s *BatchExecutorStep) Execute(ctx context.Context, state *pipeline.Pipelin
 				params[perItemParam] = coerceValue(strconv.FormatInt(ids[idx], 10), perItemType, perItemItems)
 				resp, callErr := client.CallTool(fanCtx, toolName, params)
 				if callErr != nil {
-					if isUnauthorizedErr(callErr) {
+					if meerrors.IsUnauthorized(callErr) {
 						authMu.Lock()
 						if firstErr == nil {
 							firstErr = callErr

--- a/internal/products/meegle/commands/auth.go
+++ b/internal/products/meegle/commands/auth.go
@@ -20,7 +20,59 @@ import (
 	meegle "github.com/larksuite/meegle-cli/internal/products/meegle"
 	"github.com/larksuite/meegle-cli/internal/products/meegle/auth"
 	meerrors "github.com/larksuite/meegle-cli/internal/products/meegle/errors"
+	"github.com/larksuite/meegle-cli/internal/products/meegle/mcpclient"
 )
+
+// statusVerifyTimeout caps how long `auth status` will wait on a single
+// server-side token validation call. The probe is a single tools/list RPC,
+// so 10s is generous; the upper bound keeps cron preflights from hanging
+// when the host is unreachable.
+const statusVerifyTimeout = 10 * time.Second
+
+// Reason strings surfaced in StatusResult.Reason and the human-readable
+// status text. Kept in one place so tests and docs agree.
+const (
+	statusReasonNoLocalToken      = "no local token"
+	statusReasonTokenRejected     = "token rejected by server"
+	statusReasonServerUnreachable = "server unreachable"
+)
+
+// tokenVerifier reports whether a resolved identity can actually authenticate
+// against the Meegle server. Returns "" on success, otherwise one of the
+// statusReason* constants (server-unreachable variants carry the underlying
+// error as a suffix). Extracted as a function value so tests substitute a
+// fake without standing up an HTTP server for every case.
+type tokenVerifier func(ctx context.Context, ident meegle.ResolvedIdentity) string
+
+// verifyTokenViaListTools is the production tokenVerifier. It builds an MCP
+// client from the resolved identity and delegates to verifyMCPClient for
+// the actual probe. Split so tests drive verifyMCPClient against an
+// httptest server, bypassing GetServerURL's hardcoded https URL.
+func verifyTokenViaListTools(ctx context.Context, ident meegle.ResolvedIdentity) string {
+	client := meegle.NewMCPClientFromIdentity(ident)
+	if client == nil {
+		// Defensive: caller should not invoke the verifier without a token,
+		// but if they do, surface a clear reason instead of a nil panic.
+		return statusReasonNoLocalToken
+	}
+	return verifyMCPClient(ctx, client)
+}
+
+// verifyMCPClient issues a single tools/list call to validate that the
+// token attached to client is still accepted by the server. Returns "" on
+// success, statusReasonTokenRejected on terminal auth rejection (raw 401 or
+// AUTH_EXPIRED after refresh fails), or a "server unreachable: <err>" wrapping
+// for any other error so users can tell connection refused apart from timeout
+// apart from 5xx without parsing logs.
+func verifyMCPClient(ctx context.Context, client *mcpclient.Client) string {
+	if _, err := client.ListTools(ctx); err != nil {
+		if meerrors.IsUnauthorized(err) {
+			return statusReasonTokenRejected
+		}
+		return statusReasonServerUnreachable + ": " + err.Error()
+	}
+	return ""
+}
 
 // normalizeHost extracts the host from a URL or returns the raw string.
 func normalizeHost(raw string) string {
@@ -316,13 +368,23 @@ func newLogoutCmd() *cobra.Command {
 }
 
 // StatusResult represents the structured auth status output.
+//
+// Reason is populated only when Authenticated is false and distinguishes
+// "no local token" (need login) from "token rejected by server" (need
+// re-login — refresh exhausted) from "server unreachable: <err>" (network
+// / timeout / 5xx — retryable). Cron preflights branch on this.
 type StatusResult struct {
 	Authenticated    bool    `json:"authenticated"`
 	Host             *string `json:"host"`
 	ExpiresInMinutes *int    `json:"expires_in_minutes,omitempty"`
+	Reason           string  `json:"reason,omitempty"`
 }
 
-func buildStatusResult(profileName string) (*StatusResult, error) {
+// buildStatusResult resolves the active identity and, when a token is
+// present locally, calls verify to confirm the token is still accepted by
+// the server. verify is injected so tests substitute a deterministic stub
+// — production paths wire verifyTokenViaListTools.
+func buildStatusResult(ctx context.Context, profileName string, verify tokenVerifier) (*StatusResult, error) {
 	cfg, err := loadConfig(profileName)
 	if err != nil {
 		return nil, err
@@ -342,6 +404,19 @@ func buildStatusResult(profileName string) (*StatusResult, error) {
 		return &StatusResult{
 			Authenticated: false,
 			Host:          host,
+			Reason:        statusReasonNoLocalToken,
+		}, nil
+	}
+
+	// Server-side validation: even if we hold a local token string, the
+	// server may have expired or revoked it. Without this probe, cron
+	// preflights see authenticated:true followed by a 401 on the next
+	// business call (the bug this command was fixing).
+	if reason := verify(ctx, ident); reason != "" {
+		return &StatusResult{
+			Authenticated: false,
+			Host:          host,
+			Reason:        reason,
 		}, nil
 	}
 
@@ -366,6 +441,19 @@ func buildStatusResult(profileName string) (*StatusResult, error) {
 	}, nil
 }
 
+// statusExitCode maps a StatusResult to the CLI exit code. Authenticated
+// → 0. Missing or rejected token → 1 (re-login needed). Server unreachable
+// → 2 (retryable; cron should retry rather than re-login).
+func statusExitCode(r *StatusResult) int {
+	if r.Authenticated {
+		return 0
+	}
+	if strings.HasPrefix(r.Reason, statusReasonServerUnreachable) {
+		return 2
+	}
+	return 1
+}
+
 func newStatusCmd() *cobra.Command {
 	var format string
 
@@ -382,53 +470,74 @@ func newStatusCmd() *cobra.Command {
 				}
 			}
 
-			result, err := buildStatusResult(profileName)
+			ctx, cancel := context.WithTimeout(cmd.Context(), statusVerifyTimeout)
+			defer cancel()
+
+			result, err := buildStatusResult(ctx, profileName, verifyTokenViaListTools)
 			if err != nil {
 				return err
 			}
-
-			if format == "json" || format == "ndjson" {
-				m := map[string]any{
-					"authenticated": result.Authenticated,
-					"host":          result.Host,
-				}
-				if result.Authenticated {
-					m["expires_in_minutes"] = result.ExpiresInMinutes
-				}
-				text, err := renderPayload(m, format)
-				if err != nil {
-					return err
-				}
-				fmt.Println(text)
-				if !result.Authenticated {
-					os.Exit(1)
-				}
-				return nil
+			renderStatus(result, profileName, format)
+			if code := statusExitCode(result); code != 0 {
+				os.Exit(code)
 			}
-
-			// Human-readable text output (table format)
-			if !result.Authenticated {
-				hostStr := ""
-				if result.Host != nil {
-					hostStr = fmt.Sprintf("\n  Host:    %s", *result.Host)
-				}
-				fmt.Printf("  Profile: %s%s\n  Status:  ✗ Not authenticated\n", profileName, hostStr)
-				os.Exit(1)
-				return nil
-			}
-
-			status := "✓ Authenticated"
-			if result.ExpiresInMinutes != nil {
-				if *result.ExpiresInMinutes <= 0 {
-					status = "✗ Token expired"
-				} else {
-					status = fmt.Sprintf("✓ Authenticated (%d minutes remaining)", *result.ExpiresInMinutes)
-				}
-			}
-			fmt.Printf("  Profile: %s\n  Status:  %s\n", profileName, status)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&format, "format", "json", "Output format: json, table, ndjson")
 	return cmd
+}
+
+// renderStatus writes the status to stdout in the requested format. Split
+// out so tests can assert the rendered output without intercepting os.Exit.
+func renderStatus(result *StatusResult, profileName, format string) {
+	if format == "json" || format == "ndjson" {
+		m := map[string]any{
+			"authenticated": result.Authenticated,
+			"host":          result.Host,
+		}
+		if result.Authenticated {
+			m["expires_in_minutes"] = result.ExpiresInMinutes
+		}
+		if result.Reason != "" {
+			m["reason"] = result.Reason
+		}
+		text, err := renderPayload(m, format)
+		if err != nil {
+			// renderPayload only fails on encoder bugs; surface to stderr
+			// instead of swallowing so the failure is at least visible.
+			fmt.Fprintln(os.Stderr, err)
+			return
+		}
+		fmt.Println(text)
+		return
+	}
+
+	// Human-readable text output (table format)
+	hostStr := ""
+	if result.Host != nil {
+		hostStr = fmt.Sprintf("\n  Host:    %s", *result.Host)
+	}
+	if !result.Authenticated {
+		label := "✗ Not authenticated"
+		switch {
+		case result.Reason == statusReasonTokenRejected:
+			label = "✗ Token rejected by server"
+		case strings.HasPrefix(result.Reason, statusReasonServerUnreachable):
+			// Reason carries the underlying error after the colon.
+			label = "✗ Server unreachable: " + strings.TrimPrefix(result.Reason, statusReasonServerUnreachable+": ")
+		}
+		fmt.Printf("  Profile: %s%s\n  Status:  %s\n", profileName, hostStr, label)
+		return
+	}
+
+	status := "✓ Authenticated"
+	if result.ExpiresInMinutes != nil {
+		if *result.ExpiresInMinutes <= 0 {
+			status = "✗ Token expired"
+		} else {
+			status = fmt.Sprintf("✓ Authenticated (%d minutes remaining)", *result.ExpiresInMinutes)
+		}
+	}
+	fmt.Printf("  Profile: %s%s\n  Status:  %s\n", profileName, hostStr, status)
 }

--- a/internal/products/meegle/commands/auth_test.go
+++ b/internal/products/meegle/commands/auth_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/meegle-cli/internal/products/meegle/mcpclient"
+)
+
+// jsonRPCEnvelope is a minimal local mirror of the unexported envelope inside
+// the mcpclient package — duplicated here because the field set is small and
+// stable, and we do not want to export internal RPC types just for tests.
+type jsonRPCEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+}
+
+// listToolsHandler returns an HTTP handler that responds to tools/list with
+// the canonical empty-tools envelope. Used by the "server accepts the token"
+// case where we only care that the call returns nil error.
+func listToolsHandler(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req jsonRPCEnvelope
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		resp := jsonRPCEnvelope{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result:  json.RawMessage(`{"tools":[]}`),
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+}
+
+// TestVerifyMCPClient_TokenValid pins that a 200 from tools/list resolves to
+// the empty success reason — the only state that yields authenticated:true.
+func TestVerifyMCPClient_TokenValid(t *testing.T) {
+	server := httptest.NewServer(listToolsHandler(t))
+	defer server.Close()
+
+	client := mcpclient.New(server.URL)
+	if reason := verifyMCPClient(context.Background(), client); reason != "" {
+		t.Errorf("expected empty reason on 200, got %q", reason)
+	}
+}
+
+// TestVerifyMCPClient_TokenRejected pins that a 401 maps to the
+// token-rejected reason — exit code 1 territory, user needs auth login.
+func TestVerifyMCPClient_TokenRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := mcpclient.New(server.URL)
+	reason := verifyMCPClient(context.Background(), client)
+	if reason != statusReasonTokenRejected {
+		t.Errorf("expected %q, got %q", statusReasonTokenRejected, reason)
+	}
+}
+
+// TestVerifyMCPClient_TokenRejectedAfterRefreshFailure pins the store-token
+// path: mcpclient refreshes after 401, then returns AUTH_EXPIRED when refresh
+// fails. auth status must still classify that as exit-code-1 auth rejection,
+// not retryable server-unreachable.
+func TestVerifyMCPClient_TokenRejectedAfterRefreshFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := mcpclient.New(server.URL, mcpclient.WithRefreshFunc(func() error {
+		return stderrors.New("refresh failed")
+	}))
+	reason := verifyMCPClient(context.Background(), client)
+	if reason != statusReasonTokenRejected {
+		t.Errorf("expected %q, got %q", statusReasonTokenRejected, reason)
+	}
+}
+
+// TestVerifyMCPClient_ServerUnreachable_5xx pins that a 5xx (server up but
+// failing) maps to the retryable "server unreachable" reason — exit code 2
+// territory, cron should retry rather than re-login.
+func TestVerifyMCPClient_ServerUnreachable_5xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := mcpclient.New(server.URL)
+	reason := verifyMCPClient(context.Background(), client)
+	if !strings.HasPrefix(reason, statusReasonServerUnreachable) {
+		t.Errorf("expected reason to start with %q, got %q", statusReasonServerUnreachable, reason)
+	}
+}
+
+// TestVerifyMCPClient_ServerUnreachable_ConnRefused pins that a dead host
+// (no listener) still resolves to the retryable category, not the rejected
+// category — connection refused is a network-layer signal, not an auth one.
+func TestVerifyMCPClient_ServerUnreachable_ConnRefused(t *testing.T) {
+	server := httptest.NewServer(listToolsHandler(t))
+	url := server.URL
+	server.Close() // shut down before the request to provoke connection refused
+
+	client := mcpclient.New(url)
+	reason := verifyMCPClient(context.Background(), client)
+	if !strings.HasPrefix(reason, statusReasonServerUnreachable) {
+		t.Errorf("expected reason to start with %q, got %q", statusReasonServerUnreachable, reason)
+	}
+	if reason == statusReasonTokenRejected {
+		t.Errorf("network failure must not be misclassified as token rejection")
+	}
+}
+
+// TestStatusExitCode covers the full reason → exit code mapping in one
+// place. The map is small enough that table-driven is overkill in size but
+// captures the contract cleanly for future reviewers.
+func TestStatusExitCode(t *testing.T) {
+	cases := []struct {
+		name string
+		r    StatusResult
+		want int
+	}{
+		{"authenticated", StatusResult{Authenticated: true}, 0},
+		{"no local token", StatusResult{Reason: statusReasonNoLocalToken}, 1},
+		{"token rejected", StatusResult{Reason: statusReasonTokenRejected}, 1},
+		{"server unreachable", StatusResult{Reason: statusReasonServerUnreachable + ": dial tcp: connection refused"}, 2},
+		{"server unreachable 5xx", StatusResult{Reason: statusReasonServerUnreachable + ": server returned error (500)"}, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := statusExitCode(&tc.r); got != tc.want {
+				t.Errorf("statusExitCode(%+v) = %d, want %d", tc.r, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/products/meegle/errors/errors.go
+++ b/internal/products/meegle/errors/errors.go
@@ -77,6 +77,20 @@ func NewServerError(code, message string) *MeegleError {
 	return &MeegleError{Code: code, Message: message, ExitCode: 2}
 }
 
+// IsUnauthorized reports whether err represents a terminal authentication
+// rejection from the Meegle server. mcpclient may surface this either as the
+// original 401 response or as AUTH_EXPIRED after a store-token refresh fails.
+func IsUnauthorized(err error) bool {
+	var me *MeegleError
+	if !stderrors.As(err, &me) {
+		return false
+	}
+	if me.HTTPStatus == 401 {
+		return true
+	}
+	return me.Code == "AUTH_EXPIRED"
+}
+
 // FormatText renders an error for human-readable output. When the error is
 // (or wraps) a MeegleError carrying a Suggestion, the suggestion is appended
 // on subsequent lines so users see actionable next steps. For all other

--- a/internal/products/meegle/registry.go
+++ b/internal/products/meegle/registry.go
@@ -6,7 +6,6 @@ package meegle
 import (
 	"context"
 	"encoding/json"
-	stderrors "errors"
 	"fmt"
 	"os"
 	"sort"
@@ -159,7 +158,7 @@ func (s *DynamicRegistrySetup) resolveTools(ctx context.Context) ([]types.ToolDe
 			// to "not logged in" and rely on the root command's note to tell
 			// the user which knob to rotate. SDK callers (SourceUnset with an
 			// injected client) need the 401 to surface so they can react.
-			if isUnauthorizedErr(err) && s.source != SourceUnset {
+			if meerrors.IsUnauthorized(err) && s.source != SourceUnset {
 				// ClearToken only when we actually own the credential — env
 				// and config tokens must be rotated by the user out-of-band.
 				if s.source == SourceStore && s.tokenManager != nil {
@@ -168,7 +167,7 @@ func (s *DynamicRegistrySetup) resolveTools(ctx context.Context) ([]types.ToolDe
 				s.authFailed = true
 				return nil, nil
 			}
-			if isUnauthorizedErr(err) {
+			if meerrors.IsUnauthorized(err) {
 				return nil, meerrors.NewClientError("AUTH_REJECTED",
 					"token rejected by server during tool discovery").
 					WithSuggestion(meerrors.HintConfigTokenRejected)
@@ -199,20 +198,6 @@ func (s *DynamicRegistrySetup) resolveTools(ctx context.Context) ([]types.ToolDe
 		return staleTools, nil
 	}
 	return nil, nil
-}
-
-// isUnauthorizedErr reports whether err is a terminal auth error from
-// mcpclient — either a raw 401 or the AUTH_EXPIRED sentinel returned after
-// a failed refresh attempt.
-func isUnauthorizedErr(err error) bool {
-	var me *meerrors.MeegleError
-	if !stderrors.As(err, &me) {
-		return false
-	}
-	if me.HTTPStatus == 401 {
-		return true
-	}
-	return me.Code == "AUTH_EXPIRED"
 }
 
 // buildCommandTree converts a MappedCommand list into a CommandTree.

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.