### PR TITLE
fix: keep local commands usable when tool discovery fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.7] - 2026-06-09
+
+### Fixed
+
+- `meegle` now keeps local commands (`auth`, `config`, `inspect`, `completion`, `url`) bootable when server-side tool discovery fails and no command cache exists. Dynamic business commands now return a clear `TOOL_DISCOVERY_FAILED` server error instead of causing CLI bootstrap to fail before local command handlers can run.
+
 ## [v1.0.6] - 2026-05-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -893,6 +893,7 @@ meegle auth login
 ```
 
 The command list is cached automatically and refreshed silently in the background when expired.
+When server-side command discovery fails with no usable cache, local commands such as `auth`, `config`, `inspect`, `completion`, and `url` still start normally; dynamic business commands report a `TOOL_DISCOVERY_FAILED` server error until connectivity recovers.
 
 ## Security & Risk Warnings
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -870,6 +870,7 @@ meegle auth login
 ```
 
 命令列表会自动缓存，过期后在后台静默刷新，不影响使用。
+当服务端命令发现失败且没有可用缓存时，`auth`、`config`、`inspect`、`completion`、`url` 等本地命令仍会正常启动；动态业务命令会返回 `TOOL_DISCOVERY_FAILED` 服务端错误，直到网络恢复。
 
 ## 安全与风险提示
 

--- a/cmd/meegle/main.go
+++ b/cmd/meegle/main.go
@@ -25,13 +25,10 @@ func main() {
 	// what backends observe today (e.g. "meegle-cli/v0.0.0-…+dirty").
 	mcpclient.SetVersion(version)
 
-	// Resolve mapped commands for the inspect command
-	mappedCommands := productmeegle.ResolveMappedCommands()
-
 	app, err := productmeegle.NewCLIApp(version, &productmeegle.StaticCommands{
 		Auth:       commands.NewAuthCmd(),
 		Config:     commands.NewConfigCmd(),
-		Inspect:    commands.NewInspectCmd(mappedCommands),
+		Inspect:    commands.NewInspectCmdWithProvider(productmeegle.ResolveMappedCommands),
 		Completion: commands.NewCompletionCmd(),
 		URL:        commands.NewURLCmd(),
 	})

--- a/internal/products/meegle/app.go
+++ b/internal/products/meegle/app.go
@@ -91,6 +91,7 @@ func NewCLIApp(version string, staticCmds *StaticCommands) (*cliapp.App, error) 
 		WithTokenManager(ident.TokenManager),
 		WithIdentitySource(ident.Source),
 		WithForceRefresh(forceRefresh),
+		WithDiscoveryFailureDegradation(true),
 	)
 
 	// 5. Placeholder executor (pipeline already contains McpExecutorStep; this is just a fallback)

--- a/internal/products/meegle/commands/inspect.go
+++ b/internal/products/meegle/commands/inspect.go
@@ -12,12 +12,24 @@ import (
 	"github.com/larksuite/meegle-cli/internal/products/meegle/types"
 )
 
+type InspectCommandProvider func() []types.MappedCommand
+
 func NewInspectCmd(mappedCommands []types.MappedCommand) *cobra.Command {
+	return NewInspectCmdWithProvider(func() []types.MappedCommand {
+		return mappedCommands
+	})
+}
+
+func NewInspectCmdWithProvider(provider InspectCommandProvider) *cobra.Command {
+	if provider == nil {
+		provider = func() []types.MappedCommand { return nil }
+	}
 	return &cobra.Command{
 		Use:   "inspect [command]",
 		Short: "Show parameter details for a command (e.g. inspect workitem.create)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			mappedCommands := provider()
 			if len(args) == 0 {
 				return inspectListAll(mappedCommands)
 			}

--- a/internal/products/meegle/commands/inspect_test.go
+++ b/internal/products/meegle/commands/inspect_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/larksuite/meegle-cli/internal/products/meegle/types"
+)
+
+func TestNewInspectCmdWithProviderIsLazy(t *testing.T) {
+	calls := 0
+	cmd := NewInspectCmdWithProvider(func() []types.MappedCommand {
+		calls++
+		return nil
+	})
+	if calls != 0 {
+		t.Fatalf("provider should not be called during construction, got %d calls", calls)
+	}
+
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("inspect command failed: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("provider should be called once during execution, got %d calls", calls)
+	}
+}

--- a/internal/products/meegle/dynamic/mapper.go
+++ b/internal/products/meegle/dynamic/mapper.go
@@ -3,7 +3,11 @@
 
 package dynamic
 
-import "github.com/larksuite/meegle-cli/internal/products/meegle/types"
+import (
+	"sort"
+
+	"github.com/larksuite/meegle-cli/internal/products/meegle/types"
+)
 
 type fallbackEntry struct {
 	resource    string
@@ -122,4 +126,23 @@ func MapTools(tools []types.ToolDefinition) []types.MappedCommand {
 		cmds = append(cmds, cmd)
 	}
 	return cmds
+}
+
+// FallbackResources returns the sorted, de-duplicated set of resource (command
+// group) names known to the static fallback table. It is the authoritative list
+// of business domains the CLI can map offline, so callers that need to enumerate
+// every domain without a live tool list (e.g. the discovery-failure placeholder
+// tree) should derive it from here rather than hand-maintaining a parallel list.
+func FallbackResources() []string {
+	seen := make(map[string]struct{}, len(fallbackTable))
+	resources := make([]string, 0, len(fallbackTable))
+	for _, entry := range fallbackTable {
+		if _, ok := seen[entry.resource]; ok {
+			continue
+		}
+		seen[entry.resource] = struct{}{}
+		resources = append(resources, entry.resource)
+	}
+	sort.Strings(resources)
+	return resources
 }

--- a/internal/products/meegle/dynamic/mapper_test.go
+++ b/internal/products/meegle/dynamic/mapper_test.go
@@ -164,3 +164,32 @@ func TestUnmappedToolReturnsEmptyDescription(t *testing.T) {
 		t.Errorf("expected empty description for unmapped tool, got %q", cmd.Description)
 	}
 }
+
+func TestFallbackResources(t *testing.T) {
+	got := FallbackResources()
+
+	// Strictly sorted and de-duplicated.
+	for i := 1; i < len(got); i++ {
+		if got[i-1] >= got[i] {
+			t.Fatalf("FallbackResources not strictly sorted/unique: %v", got)
+		}
+	}
+
+	// Must cover exactly the distinct resources in the fallback table.
+	want := map[string]struct{}{}
+	for _, entry := range fallbackTable {
+		want[entry.resource] = struct{}{}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("FallbackResources len = %d, want %d distinct resources", len(got), len(want))
+	}
+	for _, r := range got {
+		if _, ok := want[r]; !ok {
+			t.Errorf("unexpected resource %q", r)
+		}
+	}
+	// "resource" is a real domain that was historically easy to miss.
+	if _, ok := want["resource"]; !ok {
+		t.Fatal("fallback table missing resource domain")
+	}
+}

--- a/internal/products/meegle/pipeline.go
+++ b/internal/products/meegle/pipeline.go
@@ -212,6 +212,9 @@ func (s *McpExecutorStep) Execute(ctx context.Context, state *pipeline.PipelineC
 	if toolName == "" {
 		return nil // group node, no execution needed
 	}
+	if toolName == discoveryFailureHandlerRef {
+		return discoveryFailureCommandError(state)
+	}
 
 	if state.Values == nil {
 		state.Values = pipeline.BuildInputValues(state.Parsed)
@@ -312,6 +315,34 @@ func (s *McpExecutorStep) Execute(ctx context.Context, state *pipeline.PipelineC
 		}
 	}
 	return nil
+}
+
+func discoveryFailureCommandError(state *pipeline.PipelineContext) error {
+	command := ""
+	if state != nil && state.Parsed != nil {
+		parts := append([]string(nil), state.Parsed.FullPath...)
+		for _, arg := range state.Parsed.Args {
+			if strings.HasPrefix(arg, "-") {
+				break
+			}
+			parts = append(parts, arg)
+		}
+		command = strings.TrimSpace(strings.Join(parts, " "))
+	}
+	if command == "" {
+		command = "dynamic command"
+	}
+
+	detail := ""
+	if state != nil && state.Parsed != nil && state.Parsed.Node != nil {
+		detail = strings.TrimSpace(state.Parsed.Node.Meta.Tags[tagDiscoveryFailure])
+	}
+	message := fmt.Sprintf("tool discovery failed; dynamic Meegle command %q is unavailable", command)
+	if detail != "" {
+		message += ": " + detail
+	}
+	return meerrors.NewServerError("TOOL_DISCOVERY_FAILED", message).
+		WithSuggestion("Check Meegle server connectivity, then retry with `meegle --refresh <command>`. Local commands such as `meegle auth status`, `meegle config`, `meegle inspect`, `meegle completion`, and `meegle url` remain available.")
 }
 
 // isDryRunFlag reports whether --dry-run was passed. Lives at package scope so

--- a/internal/products/meegle/registry.go
+++ b/internal/products/meegle/registry.go
@@ -6,6 +6,7 @@ package meegle
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"sort"
@@ -19,33 +20,47 @@ import (
 	"github.com/larksuite/meegle-cli/pkg/framework/registry"
 )
 
-// resourceDescriptions provides a description for each resource group.
+// resourceDescriptions provides optional help text for each resource group.
+// It is description-only metadata: lookups fall back to a generated default
+// when a group is absent, so it must NOT be treated as the authoritative list
+// of domains (that list comes from dynamic.FallbackResources).
 var resourceDescriptions = map[string]string{
-	"workitem":   "Work Item domain — CRUD, field metadata, time tracking, comments",
-	"workflow":   "Workflow domain — node transitions, state transitions, node fields",
-	"subtask":    "Subtask domain — subtask operations",
-	"comment":    "Comment domain — cross-entity commenting",
-	"workhour":   "Work Hour domain — time tracking and scheduling",
-	"relation":   "Relation domain — work item relationships",
-	"mywork":     "My Work domain — cross-space personal to-do/done items",
-	"view":       "View domain — create, query, update views",
-	"chart":      "Chart domain — chart queries",
-	"team":       "Team domain — space members, team queries",
-	"user":       "User domain — user information search",
-	"project":    "Project domain — project space queries",
-	"attachment": "Attachment domain — upload/download files via Lark Project attachment protocol",
+	"workitem":    "Work Item domain — CRUD, field metadata, time tracking, comments",
+	"workflow":    "Workflow domain — node transitions, state transitions, node fields",
+	"subtask":     "Subtask domain — subtask operations",
+	"comment":     "Comment domain — cross-entity commenting",
+	"workhour":    "Work Hour domain — time tracking and scheduling",
+	"relation":    "Relation domain — work item relationships",
+	"mywork":      "My Work domain — cross-space personal to-do/done items",
+	"view":        "View domain — create, query, update views",
+	"chart":       "Chart domain — chart queries",
+	"team":        "Team domain — space members, team queries",
+	"user":        "User domain — user information search",
+	"project":     "Project domain — project space queries",
+	"attachment":  "Attachment domain — upload/download files via Lark Project attachment protocol",
+	"deliverable": "Deliverable domain — deliverable listing and related work item context",
+	"wbs":         "WBS domain — plan-table draft and instance workflows",
+	"resource":    "Resource domain — resource-library template (resource instance) operations",
 }
+
+const (
+	discoveryFailureHandlerRef      = "__meegle_tool_discovery_failed__"
+	tagDiscoveryFailure             = "meegle_discovery_failure"
+	tagRouterAllowUnknownFlags      = "router_allow_unknown_flags"
+	discoveryFailureFallbackVersion = "dynamic-discovery-failed"
+)
 
 // DynamicRegistrySetup builds the command tree via MCP dynamic discovery.
 type DynamicRegistrySetup struct {
-	client       discovery.ToolLister
-	cache        *ToolCache
-	tokenManager *auth.TokenManager
-	source       IdentitySource
-	globalFlags  []registry.FlagDef
-	commands     []types.MappedCommand // populated by Setup, read by pipeline steps
-	authFailed   bool                  // set when tool discovery fails due to 401 (expired/revoked token)
-	forceRefresh bool                  // when true, bypass fresh cache and fetch from server
+	client                   discovery.ToolLister
+	cache                    *ToolCache
+	tokenManager             *auth.TokenManager
+	source                   IdentitySource
+	globalFlags              []registry.FlagDef
+	commands                 []types.MappedCommand // populated by Setup, read by pipeline steps
+	authFailed               bool                  // set when tool discovery fails due to 401 (expired/revoked token)
+	forceRefresh             bool                  // when true, bypass fresh cache and fetch from server
+	degradeDiscoveryFailures bool                  // CLI startup only: keep static commands bootable on non-auth discovery errors
 }
 
 // RegistryOption configures optional parameters for DynamicRegistrySetup.
@@ -85,6 +100,15 @@ func WithForceRefresh(force bool) RegistryOption {
 	}
 }
 
+// WithDiscoveryFailureDegradation keeps CLI bootstrap alive when the server is
+// unreachable and no cache exists. SDK callers should keep the default hard
+// failure so programmatic clients can handle discovery errors explicitly.
+func WithDiscoveryFailureDegradation(enabled bool) RegistryOption {
+	return func(s *DynamicRegistrySetup) {
+		s.degradeDiscoveryFailures = enabled
+	}
+}
+
 // IdentitySource reports the source of the active token (for external
 // callers that want to render source-specific hints after Setup runs).
 func (s *DynamicRegistrySetup) IdentitySource() IdentitySource {
@@ -108,6 +132,12 @@ func NewDynamicRegistrySetup(client discovery.ToolLister, cache *ToolCache, opts
 func (s *DynamicRegistrySetup) Setup(ctx context.Context) (*registry.CommandTree, error) {
 	tools, err := s.resolveTools(ctx)
 	if err != nil {
+		if s.degradeDiscoveryFailures && !isUnauthorizedErr(err) {
+			s.commands = nil
+			tree := buildDiscoveryFailureTree(err)
+			tree.GlobalFlags = s.globalFlags
+			return tree, nil
+		}
 		return nil, err
 	}
 	commands := dynamic.MapTools(tools)
@@ -198,6 +228,61 @@ func (s *DynamicRegistrySetup) resolveTools(ctx context.Context) ([]types.ToolDe
 		return staleTools, nil
 	}
 	return nil, nil
+}
+
+func buildDiscoveryFailureTree(err error) *registry.CommandTree {
+	// Derive the domain list from the static fallback table — the authoritative
+	// set of business domains the CLI knows — so every real domain gets a clean
+	// TOOL_DISCOVERY_FAILED placeholder. resourceDescriptions only supplies help
+	// text and must NOT gate which domains are covered (a domain missing from it
+	// previously fell through to "unknown command").
+	groupNames := dynamic.FallbackResources()
+
+	nodes := make([]*registry.CommandNode, 0, len(groupNames))
+	errText := strings.TrimSpace(fmt.Sprint(err))
+	for _, name := range groupNames {
+		desc := resourceDescriptions[name]
+		if desc == "" {
+			desc = fmt.Sprintf("%s domain", name)
+		}
+		nodes = append(nodes, &registry.CommandNode{
+			Name: name,
+			Help: registry.HelpText{
+				Brief: desc,
+				Long:  "Dynamic Meegle commands are unavailable because tool discovery failed.",
+			},
+			Args: []registry.ArgDef{{
+				Name:     "command-and-flags",
+				Variadic: true,
+			}},
+			HandlerRef: discoveryFailureHandlerRef,
+			Meta: registry.NodeMeta{
+				Hidden: true,
+				Tags: map[string]string{
+					tagDiscoveryFailure:        errText,
+					tagRouterAllowUnknownFlags: "1",
+				},
+			},
+		})
+	}
+	return &registry.CommandTree{
+		Version: discoveryFailureFallbackVersion,
+		Nodes:   nodes,
+	}
+}
+
+// isUnauthorizedErr reports whether err is a terminal auth error from
+// mcpclient — either a raw 401 or the AUTH_EXPIRED sentinel returned after
+// a failed refresh attempt.
+func isUnauthorizedErr(err error) bool {
+	var me *meerrors.MeegleError
+	if !stderrors.As(err, &me) {
+		return false
+	}
+	if me.HTTPStatus == 401 {
+		return true
+	}
+	return me.Code == "AUTH_EXPIRED"
 }
 
 // buildCommandTree converts a MappedCommand list into a CommandTree.

--- a/internal/products/meegle/registry_test.go
+++ b/internal/products/meegle/registry_test.go
@@ -4,15 +4,20 @@
 package meegle
 
 import (
+	"bytes"
 	"context"
 	stderrors "errors"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/larksuite/meegle-cli/internal/products/meegle/auth"
+	"github.com/larksuite/meegle-cli/internal/products/meegle/dynamic"
 	meerrors "github.com/larksuite/meegle-cli/internal/products/meegle/errors"
 	"github.com/larksuite/meegle-cli/internal/products/meegle/types"
 	"github.com/larksuite/meegle-cli/pkg/framework/registry"
+	"github.com/larksuite/meegle-cli/pkg/runtime/cliapp"
 )
 
 // unauthorizedLister is a ToolLister stub that always returns a 401 MeegleError,
@@ -162,6 +167,169 @@ func TestDynamicRegistrySetup_GracefulNoClient(t *testing.T) {
 	}
 	if len(tree.Nodes) != 0 {
 		t.Errorf("expected 0 nodes (no MCP discovery), got %d", len(tree.Nodes))
+	}
+}
+
+func TestDynamicRegistrySetup_DiscoveryErrorWithoutDegradationHardFails(t *testing.T) {
+	lister := &errorLister{err: stderrors.New("network unreachable")}
+	setup := NewDynamicRegistrySetup(lister, nil)
+
+	_, err := setup.Setup(context.Background())
+	if err == nil {
+		t.Fatal("expected discovery error without CLI degradation")
+	}
+	if !strings.Contains(err.Error(), "tool discovery failed") {
+		t.Fatalf("expected tool discovery failure, got: %v", err)
+	}
+}
+
+func TestDynamicRegistrySetup_DegradesDiscoveryErrorToPlaceholderTree(t *testing.T) {
+	lister := &errorLister{err: stderrors.New("network unreachable")}
+	setup := NewDynamicRegistrySetup(lister, nil,
+		WithGlobalFlags(MeegleGlobalFlags),
+		WithDiscoveryFailureDegradation(true),
+	)
+
+	tree, err := setup.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("expected CLI degradation, got error: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("expected non-nil placeholder tree")
+	}
+	if tree.Version != discoveryFailureFallbackVersion {
+		t.Fatalf("expected fallback tree version, got %q", tree.Version)
+	}
+	if len(tree.GlobalFlags) == 0 {
+		t.Error("expected global flags to stay registered")
+	}
+	workitem := findNodeByName(tree.Nodes, "workitem")
+	if workitem == nil {
+		t.Fatal("expected workitem placeholder node")
+	}
+	if workitem.HandlerRef != discoveryFailureHandlerRef {
+		t.Errorf("expected discovery failure handler, got %q", workitem.HandlerRef)
+	}
+	if workitem.Meta.Tags[tagRouterAllowUnknownFlags] != "1" {
+		t.Error("expected placeholder to allow unknown business flags")
+	}
+	if !strings.Contains(workitem.Meta.Tags[tagDiscoveryFailure], "network unreachable") {
+		t.Errorf("expected original error in placeholder tag, got %q", workitem.Meta.Tags[tagDiscoveryFailure])
+	}
+}
+
+// The placeholder tree must cover every business domain the CLI knows about,
+// otherwise an unlisted domain falls through to cobra's "unknown command"
+// instead of the clean TOOL_DISCOVERY_FAILED error. Deriving the domains from
+// dynamic.FallbackResources keeps this complete as new tools are added; this
+// test guards against regressing to a hand-maintained subset.
+func TestDegradesDiscoveryError_CoversEveryFallbackDomain(t *testing.T) {
+	lister := &errorLister{err: stderrors.New("network unreachable")}
+	setup := NewDynamicRegistrySetup(lister, nil,
+		WithDiscoveryFailureDegradation(true),
+	)
+
+	tree, err := setup.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("expected CLI degradation, got error: %v", err)
+	}
+
+	domains := dynamic.FallbackResources()
+	if len(tree.Nodes) != len(domains) {
+		t.Fatalf("placeholder node count = %d, want %d (one per fallback domain)", len(tree.Nodes), len(domains))
+	}
+	for _, name := range domains {
+		node := findNodeByName(tree.Nodes, name)
+		if node == nil {
+			t.Errorf("missing placeholder node for domain %q", name)
+			continue
+		}
+		if node.HandlerRef != discoveryFailureHandlerRef {
+			t.Errorf("domain %q: handler = %q, want discovery-failure handler", name, node.HandlerRef)
+		}
+	}
+	// "resource" specifically regressed before this guard existed.
+	if findNodeByName(tree.Nodes, "resource") == nil {
+		t.Error("expected resource domain to have a placeholder node")
+	}
+}
+
+func TestCLIApp_DiscoveryErrorStillAllowsStaticCommand(t *testing.T) {
+	lister := &errorLister{err: stderrors.New("network unreachable")}
+	setup := NewDynamicRegistrySetup(lister, nil,
+		WithGlobalFlags(MeegleGlobalFlags),
+		WithDiscoveryFailureDegradation(true),
+	)
+	ran := false
+	authCmd := &cobra.Command{Use: "auth"}
+	authCmd.AddCommand(&cobra.Command{
+		Use: "status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ran = true
+			_, _ = cmd.OutOrStdout().Write([]byte("static ok\n"))
+			return nil
+		},
+	})
+
+	app, err := cliapp.New(
+		cliapp.WithAppName("meegle"),
+		cliapp.WithVersion("test"),
+		cliapp.WithSetup(setup),
+		cliapp.WithPipelineFactory(newPipelineFactory(setup)),
+		cliapp.WithRootCommandCustomizer(rootCustomizer(&StaticCommands{Auth: authCmd}, nil, setup)),
+	)
+	if err != nil {
+		t.Fatalf("expected app bootstrap to succeed, got: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = app.ExecuteWithIO(context.Background(), []string{"auth", "status"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("expected static command to run, got: %v\nstderr=%s", err, stderr.String())
+	}
+	if !ran {
+		t.Fatal("expected static command handler to run")
+	}
+	if !strings.Contains(stdout.String(), "static ok") {
+		t.Fatalf("expected static command output, got: %q", stdout.String())
+	}
+}
+
+func TestCLIApp_DiscoveryErrorDynamicCommandReturnsClearError(t *testing.T) {
+	lister := &errorLister{err: stderrors.New("network unreachable")}
+	setup := NewDynamicRegistrySetup(lister, nil,
+		WithGlobalFlags(MeegleGlobalFlags),
+		WithDiscoveryFailureDegradation(true),
+	)
+	app, err := cliapp.New(
+		cliapp.WithAppName("meegle"),
+		cliapp.WithVersion("test"),
+		cliapp.WithSetup(setup),
+		cliapp.WithPipelineFactory(newPipelineFactory(setup)),
+	)
+	if err != nil {
+		t.Fatalf("expected app bootstrap to succeed, got: %v", err)
+	}
+
+	_, err = app.Invoke(context.Background(), []string{"workitem", "create", "--project-key", "P", "--dry-run"})
+	if err == nil {
+		t.Fatal("expected dynamic command discovery error")
+	}
+	var me *meerrors.MeegleError
+	if !stderrors.As(err, &me) {
+		t.Fatalf("expected MeegleError, got %T: %v", err, err)
+	}
+	if me.Code != "TOOL_DISCOVERY_FAILED" {
+		t.Fatalf("expected TOOL_DISCOVERY_FAILED, got %q", me.Code)
+	}
+	if me.ExitCode != 2 {
+		t.Fatalf("expected server-unreachable exit code 2, got %d", me.ExitCode)
+	}
+	if !strings.Contains(me.Message, "workitem create") || !strings.Contains(me.Message, "network unreachable") {
+		t.Fatalf("expected command and original error in message, got: %s", me.Message)
+	}
+	if !strings.Contains(me.Suggestion, "auth status") {
+		t.Fatalf("expected suggestion to mention local commands, got: %s", me.Suggestion)
 	}
 }
 

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",

--- a/pkg/framework/router/router.go
+++ b/pkg/framework/router/router.go
@@ -165,6 +165,9 @@ func (r *CommandRouter) registerNode(parent *cobra.Command, node *registry.Comma
 		Hidden:     node.Meta.Hidden,
 		Deprecated: node.Meta.Deprecated,
 	}
+	if node.Meta.Tags["router_allow_unknown_flags"] == "1" {
+		cmd.FParseErrWhitelist.UnknownFlags = true
+	}
 	cmd.Annotations = map[string]string{"command_path": node.FullPathString()}
 	for _, flag := range node.Flags {
 		registerFlag(cmd.PersistentFlags(), flag)

--- a/skills/meegle/SKILL.md
+++ b/skills/meegle/SKILL.md
@@ -78,7 +78,13 @@ description: |
 | --project-key | string | 是 | 空间标识（支持名称、simpleName、projectKey） |
 | --mql | string | 是（翻页时可用 session_id 替代） | MQL 查询语句（完整 SQL） |
 | --session-id | string | 否 | 分页会话 ID，传入后不解析 MQL 直接翻页 |
-| --group-pagination-list | array | 否 | 分页信息，首次查询可不传 |
+| --group-pagination-list | array | 否 | 分组分页信息，首次查询可不传；翻页时传 `[{ "group_id": "分组ID", "page_num": 页码 }]` |
+
+**分组分页**：
+- `--group-pagination-list` 是数组，当前只支持传一组分页数据；元素结构为 `{ "group_id": string, "page_num": number }`
+- `group_id` 取首查返回的 `list[].group_infos[].group_id`；无分组查询返回的默认分组 ID 为 `"1"`，翻页时也传 `"1"`
+- `page_num` 从 1 开始；MQL 首查不传分页参数时默认返回第一页，单页最多 50 条。当前接口没有 `page_size` / `page_token` 子字段
+- 翻页时传首查返回的 `session_id` 和目标分组的分页参数；传 `session_id` 后后端不再解析 MQL，只按已有会话取对应分组页
 
 **要点**：
 - 先用 `workitem meta-fields` / `workitem meta-roles` 获取字段与角色配置；查不到直接报错不要继续
@@ -246,10 +252,14 @@ description: |
 
 ## Resource 资源库
 
-> 资源库（资源模板）管理。`resource create` 创建资源实例；查看资源库的字段 / 角色配置用 `resource meta-fields`。详细参数表见 [references/misc.md](references/misc.md)。
+> 资源库（资源模板）管理。`resource create` 当前对应 MCP `create_resource_work_item`，用于创建资源实例；查看资源库的字段 / 角色配置用 `resource meta-fields`。详细参数表见 [references/misc.md](references/misc.md)。
 
 ### resource create
 在已启用资源库的工作项类型下创建资源模板（资源实例）。创建前先调 `resource meta-fields` 取字段 / 角色配置。
+
+**语义边界**：
+- 创建资源实例：`work_item_type_key` 是资源库启用的工作项类型；`template_id` 是该类型下的流程模板 ID/名称；`fields` / `roles` 是新资源实例自身的字段和角色。
+- 从资源实例创建普通工作项：不要把已有资源实例 ID 填到 `work_item_type_key` 或 `template_id`。必须以当前 `resource create` 的 inspect/schema 为准确认是否有源资源实例参数；若当前 schema 未暴露该参数，先向用户说明无法确认自动化参数，不要猜。
 
 ---
 

--- a/skills/meegle/references/api-examples.md
+++ b/skills/meegle/references/api-examples.md
@@ -43,6 +43,18 @@ meegle workitem meta-roles --page-num 1 --project-key 空间key --work-item-type
 meegle workitem query --project-key 空间key --session-id {{session_id}} --mql 'SELECT `work_item_id`, `name`, `current_owners`, `status` FROM `空间名`.`story` WHERE `is_archived` = 0' --group-pagination-list '{{group_pagination_list}}' --format json
 ```
 
+继续查询无分组结果的第 2 页（无分组时 `group_id` 传 `"1"`，`session_id` 使用上一次查询返回值）：
+
+```bash
+meegle workitem query --project-key 空间key --session-id 上次返回的session_id --mql '' --group-pagination-list '[{"group_id":"1","page_num":2}]' --format json
+```
+
+继续查询某个分组的第 3 页（`group_id` 来自首查返回的 `list[].group_infos[].group_id`）：
+
+```bash
+meegle workitem query --project-key 空间key --session-id 上次返回的session_id --mql '' --group-pagination-list '[{"group_id":"分组ID","page_num":3}]' --format json
+```
+
 ### workitem get
 ```bash
 meegle workitem get --work-item-id 工作项ID或名称 --fields '{{fields}}' --project-key 空间key --format json

--- a/skills/meegle/references/misc.md
+++ b/skills/meegle/references/misc.md
@@ -121,6 +121,10 @@
 ### resource create
 在已启用资源库的工作项类型下创建资源模板（资源实例）。先调 `resource meta-fields` 取字段 / 角色配置。
 
+**创建资源实例 vs 从资源实例创建普通工作项**：
+- 创建资源实例：使用 `resource create`；`work_item_type_key` 表示资源库启用的工作项类型，`template_id` 表示流程模板，`fields` / `roles` 描述新资源实例自身。
+- 从资源实例创建普通工作项：这是“基于已有资源实例派生/创建业务工作项”的语义，参数通常需要源资源实例标识。当前命令参数必须以 `inspect` / schema 为准；若没有显式源资源实例参数，不要把源资源实例 ID 塞进 `work_item_type_key`、`template_id` 或普通字段里猜测调用。
+
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | --project-key | string | 是 | 空间 key |

--- a/skills/meegle/references/sop-transition-node.md
+++ b/skills/meegle/references/sop-transition-node.md
@@ -85,15 +85,41 @@ meegle workflow list-state-required --work-item-id 工作项ID --state-key 目�
 
 传入 `mode = "unfinished"` 仅查未完成必填项。从返回中识别每个字段的 `form_item_type`（node_field / field）和 `field_type`。
 
-**4.2 硬拦截：不可写入的字段类型**
+**4.2 评审结论 / 评审意见（`node_finished_conclusion` / `node_finished_opinion`）**
+
+这是节点的「整体完成结论 / 意见」，可经接口读写，但**前提是该节点已启用这两个字段**——只有节点开了「完成结论」配置，`workflow get-node` 的 `form_items` 里才会出现它们；没启用时写入会报 `node field is invalid`。所以**先读 `form_items` 确认字段存在，再写**。
+
+**读取**：用 `workflow get-node` 按 `field_key_list` 读，或用 `workitem get` 按 `fields` 读。字段未启用时返回里不会出现对应项：
+
+```bash
+meegle workflow get-node --work-item-id 工作项ID --field-key-list '["node_finished_conclusion","node_finished_opinion"]' --need-sub-task {{need_sub_task}} --page-num {{page_num}} --project-key 空间key --node-id-list '["节点node_key"]' --format json
+```
+
+**查询结论选项**：结论是 select 型，用 `workflow meta-node-fields` 查 options，写入用其 `option_id`：
+
+```bash
+meegle workflow meta-node-fields --field-keys '["node_finished_conclusion"]' --field-types '{{field_types}}' --project-key 空间key --work-item-type 类型key --query '{{query}}' --format json
+```
+
+**写入**：经 `workflow update-node` 的 `fields` 写入——结论写合法 `option_id`，意见写文本。
+
+> 🚨 **必须分两次调用，一次只写一个字段。** `workflow update-node` 的 `fields` 数组里如果同时放结论和意见，**只有第一个字段会落库，其余被静默丢弃**（返回仍是 `success`）。这和「排期 / 负责人不要同时改」是同一类约束。每次写完都要 `workflow get-node` 回读校验，不要凭返回的 success 断言已写入。
+
+```bash
+meegle workflow update-node --work-item-id 工作项ID --node-schedule '{{node_schedule}}' --schedules '{{schedules}}' --fields '[{"field_key":"node_finished_conclusion","field_value":"option_id"}]' --project-key 空间key --node-id 节点node_key --node-owners '{{node_owners}}' --format json
+```
+
+```bash
+meegle workflow update-node --work-item-id 工作项ID --node-schedule '{{node_schedule}}' --schedules '{{schedules}}' --fields '[{"field_key":"node_finished_opinion","field_value":"评审意见文本"}]' --project-key 空间key --node-id 节点node_key --node-owners '{{node_owners}}' --format json
+```
+
+**4.3 硬拦截：不可写入的字段类型**
 
 以下字段类型 **API 无法写入**。如果被设为流转必填项，**立即中断当前节点的流转**并告知用户：
 
 | 字段类型 | 说明 | 拦截原因 |
 |---|---|---|
 | `actual_work_time` | 实际工时 | 需在页面手动登记 |
-| `node_finished_conclusion` | 整体完成结论 | `update_node` 静默忽略，返回 success 但实际未写入 |
-| `node_finished_opinion` | 整体完成意见 | `update_node` 静默忽略，返回 success 但实际未写入 |
 | `owners_finished_info` | 负责人完成结论与意见 | 仅各负责人可在页面操作 |
 | `vote-boolean` / `vote-option` / `vote-option-multi` | 投票类 | 仅支持页面交互 |
 | `compound_field` / `multi_user_compound_field` | 复合明细表 | API 暂不支持 |
@@ -102,7 +128,7 @@ meegle workflow list-state-required --work-item-id 工作项ID --state-key 目�
 🚨 遇到硬拦截时输出：
 > "节点流转失败。当前节点【节点名称】设置了必须填写【字段名称】（类型：xxx）才能流转。由于该字段类型不支持自动化补充，请您在飞书项目页面手动填写后，再通知我继续流转。"
 
-**4.3 可补充字段的值转换**
+**4.4 可补充字段的值转换**
 
 **人员字段处理规则（极重要）：**
 - 用户明确指定了人员 → `user search` 转 userkey
@@ -119,6 +145,8 @@ meegle workflow list-state-required --work-item-id 工作项ID --state-key 目�
 | `point` (number) | `node_schedule` 中的 `points` 字段 |
 
 > 清空节点负责人时传空数组 `[]`（不是 `["_all"]`，`["_all"]` 仅用于 `update_field` 中删除角色配置）。
+
+> 评审结论 / 意见（`node_finished_conclusion` / `node_finished_opinion`）的读写口径见 §4.2：需节点已启用该字段，且**结论与意见必须分两次 `update-node` 调用**（一次只落第一个字段）。
 
 **通用字段类型转换**（完整格式见主文档 [SKILL.md](../SKILL.md)「字段值格式」）：
 
@@ -152,7 +180,7 @@ meegle workflow list-state-required --work-item-id 工作项ID --state-key 目�
 - `form_item_type = "field"` → `workitem update`（工作项级别）
 - 节点枚举值用 `workflow meta-node-fields` 查询；工作项枚举值用 `workitem meta-fields` 查询（用 `field_keys` 精确或 `field_query` 模糊搜索，禁止逐页遍历）
 
-**4.4 字段补充执行策略**
+**4.5 字段补充执行策略**
 
 🚨 **效率要求**：一轮对话内并行完成所有必填字段补充。
 
@@ -161,7 +189,7 @@ meegle workflow list-state-required --work-item-id 工作项ID --state-key 目�
 3. 其他节点字段通过 `workflow update-node` 的 `fields` 参数批量更新
 4. 工作项字段通过 `workitem update` 的 `fields` 参数批量更新
 
-**4.5 用户未提供值时**：
+**4.6 用户未提供值时**：
 - 人员类 → **必须询问**
 - 排期/日期类 → **询问用户**
 - 枚举类 → 列出选项让用户选

--- a/skills/meegle/references/workflow.md
+++ b/skills/meegle/references/workflow.md
@@ -23,9 +23,12 @@
 | --mode | string | 否 | 默认查所有必填项；传 `unfinished` 仅查未完成必填项 |
 
 ## workflow meta-node-fields
-查看节点字段配置。`workflow update-node` 修改节点自定义字段前用来确认合法 field_key。
+查看节点字段配置。`workflow update-node` 修改节点自定义字段前用来确认合法 field_key、字段类型与 options。查询评审结论选项时按 `field_keys=["node_finished_conclusion"]` 精确查询，并从返回配置的 options / 选项列表中取合法值。
 
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | --project-key | string | 是 | 空间 key |
 | --work-item-type | string | 是 | 工作项类型 |
+| --field-keys | array | 否 | 精确匹配节点字段 key 或名称，如 `["node_finished_conclusion"]` |
+| --field-types | array | 否 | 按节点字段类型筛选 |
+| --query | string | 否 | 按字段 name / key 模糊搜索 |


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.