### PR TITLE
feat: surface backend logid via --envelope for request tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.8] - 2026-06-09
+
+### Added
+
+- `--envelope` now surfaces the backend `logid` under `meta.logid` when present. Previously the MCP server emitted the trace id as a `logid:` content entry, which the CLI stripped into `Response.LogID` but only forwarded to `slog.Debug` — and since no default slog handler is configured, the id was silently dropped. Oncall now has a way to ask end users for an argos-lookupable trace id: re-run with `--envelope` and read `meta.logid`. The id is still suppressed without `--envelope` so default output stays clean for piping. Only covers the single-call path for now; batch (`+batch-get`) per-row logid remains a follow-up
+
 ## [v1.0.7] - 2026-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ meegle workflow get-node --work-item-id 12345 --need-sub-task
 | `--set` | | Set nested parameters (repeatable) |
 | `--params` | `-P` | Full JSON parameter body; prefix with `@` to read from a file (e.g. `--params @body.json`) |
 | `--dry-run` | | Render request without executing |
+| `--envelope` | | Wrap success output as `{data, meta, error}` — `meta.logid` carries the backend trace id when present |
 | `--verbose` | `-v` | Verbose output |
 | `--profile` | | Use a specific configuration profile |
 | `--refresh` | | Refresh cached commands from server (bypass the local 24 h cache) |
@@ -714,6 +715,21 @@ when you do not project them. Drill into records explicitly via
 and `--format ndjson`, a single-key wrapper like `{"list":[...]}`
 (no sibling metadata) is still peeled into rows — the peel is
 loss-less.
+
+### Tracing with `--envelope`
+
+When something looks wrong (silent success, unexpected payload) and you
+want to ask oncall to trace the exact call, add `--envelope`:
+
+```bash
+meegle workflow update-node --work-item-id 12345 \
+  --set node_schedule.points=10 --envelope
+```
+
+The success output is wrapped as `{data, meta, error}`, and `meta.logid`
+carries the backend trace id (when the server returns one). Hand that id
+to oncall to look up the request in argos. Without `--envelope` the id is
+suppressed so the default output stays clean for piping.
 
 ### Dry Run
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -644,6 +644,7 @@ meegle workflow get-node --work-item-id 12345 --need-sub-task
 | `--set` | | 设置嵌套参数（可重复） |
 | `--params` | `-P` | 完整 JSON 参数体；以 `@` 开头改为从文件读取（如 `--params @body.json`） |
 | `--dry-run` | | 只渲染请求，不实际执行 |
+| `--envelope` | | 将成功输出包装为 `{data, meta, error}` —— 后端返回 logid 时挂在 `meta.logid` |
 | `--verbose` | `-v` | 详细输出 |
 | `--profile` | | 指定配置 profile |
 | `--refresh` | | 从服务端刷新本地命令缓存（旁路 24 小时缓存） |
@@ -691,6 +692,20 @@ meegle mywork todo --action done --page-num 1 \
 ### 元数据保留
 
 默认渲染下，响应的完整结构在所有 `--format` 中都会保留：列表接口返回的 `{"list":[...], "total":N, "pagination":{...}}` 原样呈现 —— 即使你没有在 `--select` 中点名，`total` / `pagination` 这些元数据字段依然可见。要钻到具体记录就显式用 `--select`（配合上面的广播语法）。`--format table` 和 `--format ndjson` 下，形如 `{"list":[...]}` 的单键包装（没有兄弟元数据）仍然会被无损展开成行展示。
+
+### 通过 `--envelope` 拿到 logid
+
+遇到"返回 success 但实际没生效"、"输出不符合预期"等情况，需要让 oncall
+按 logid 反查具体调用时，加上 `--envelope`：
+
+```bash
+meegle workflow update-node --work-item-id 12345 \
+  --set node_schedule.points=10 --envelope
+```
+
+成功输出会被包装为 `{data, meta, error}`，后端返回 logid 时挂在
+`meta.logid` 里——把这个 id 交给 oncall 就能在 argos 定位到这次请求。
+不加 `--envelope` 时 logid 会被抑制，保持默认输出干净便于管道处理。
 
 ### Dry Run
 

--- a/internal/products/meegle/mcpclient/response.go
+++ b/internal/products/meegle/mcpclient/response.go
@@ -11,6 +11,23 @@ import (
 	meerrors "github.com/larksuite/meegle-cli/internal/products/meegle/errors"
 )
 
+// logIDPrefixes is the set of prefixes the MCP server has historically used
+// to mark the trace id text entry. The current server emits "log_id:"; older
+// notes/comments referenced "logid:". Match both so a server-side rename does
+// not silently drop the id again (which is what happened before — the code
+// matched "logid:" but the server emitted "log_id:", so Response.LogID was
+// always empty and the slog.Debug call hid the breakage).
+var logIDPrefixes = []string{"log_id:", "logid:"}
+
+func stripLogIDPrefix(text string) (id string, matched bool) {
+	for _, p := range logIDPrefixes {
+		if rest, ok := strings.CutPrefix(text, p); ok {
+			return strings.TrimSpace(rest), true
+		}
+	}
+	return "", false
+}
+
 type Response struct {
 	Data  any
 	Raw   string
@@ -60,8 +77,8 @@ func unwrapResponse(raw json.RawMessage) (*Response, error) {
 	// Filter logid only for non-error responses
 	var dataTexts []string
 	for _, text := range allTexts {
-		if strings.HasPrefix(text, "logid:") {
-			result.LogID = text
+		if id, ok := stripLogIDPrefix(text); ok {
+			result.LogID = id
 			slog.Debug(text)
 		} else {
 			dataTexts = append(dataTexts, text)

--- a/internal/products/meegle/mcpclient/response_test.go
+++ b/internal/products/meegle/mcpclient/response_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mcpclient
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The production MCP server emits the trace id as a content entry prefixed
+// with "log_id:" (underscore). An earlier version of this code matched only
+// "logid:", which silently dropped every id — the slog.Debug hop hid the
+// breakage until --envelope tried to surface meta.logid and saw nothing. Pin
+// the live prefix here so a server-side rename or local prefix typo fails
+// loudly instead of leaking back into the same silent-drop bug.
+func TestUnwrapResponse_CapturesLogIDFromLiveServerPrefix(t *testing.T) {
+	raw := mustMarshal(t, mcpToolResponse{
+		Content: []mcpContentEntry{
+			{Type: "text", Text: `{"ok":true}`},
+			{Type: "text", Text: "log_id: 20260519145706D6A0F7B0A114DB405B66"},
+		},
+	})
+
+	got, err := unwrapResponse(raw)
+	if err != nil {
+		t.Fatalf("unwrapResponse failed: %v", err)
+	}
+	if got.LogID != "20260519145706D6A0F7B0A114DB405B66" {
+		t.Errorf("expected stripped log_id, got %q", got.LogID)
+	}
+	// Data must NOT carry the log_id text entry — otherwise downstream
+	// formatters would render it as part of the payload.
+	dataMap, ok := got.Data.(map[string]any)
+	if !ok || dataMap["ok"] != true {
+		t.Errorf("expected Data to be the JSON object {ok:true}, got %#v", got.Data)
+	}
+}
+
+// Historical alias: tolerate the older "logid:" prefix in case the server
+// emits both shapes during a migration window.
+func TestUnwrapResponse_AcceptsLegacyLogidPrefix(t *testing.T) {
+	raw := mustMarshal(t, mcpToolResponse{
+		Content: []mcpContentEntry{
+			{Type: "text", Text: "logid:abc"},
+			{Type: "text", Text: `{"ok":true}`},
+		},
+	})
+	got, err := unwrapResponse(raw)
+	if err != nil {
+		t.Fatalf("unwrapResponse failed: %v", err)
+	}
+	if got.LogID != "abc" {
+		t.Errorf("expected LogID=abc, got %q", got.LogID)
+	}
+}
+
+func TestUnwrapResponse_NoLogIDLeavesFieldEmpty(t *testing.T) {
+	raw := mustMarshal(t, mcpToolResponse{
+		Content: []mcpContentEntry{
+			{Type: "text", Text: `{"ok":true}`},
+		},
+	})
+	got, err := unwrapResponse(raw)
+	if err != nil {
+		t.Fatalf("unwrapResponse failed: %v", err)
+	}
+	if got.LogID != "" {
+		t.Errorf("expected empty LogID when server omits the entry, got %q", got.LogID)
+	}
+}
+
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/internal/products/meegle/pipeline.go
+++ b/internal/products/meegle/pipeline.go
@@ -305,16 +305,44 @@ func (s *McpExecutorStep) Execute(ctx context.Context, state *pipeline.PipelineC
 				data = fn(data)
 			}
 		}
+		metadata := map[string]any{
+			"tool":        toolName,
+			"command":     strings.Join(state.Parsed.FullPath, " "),
+			"duration_ms": duration.Milliseconds(),
+		}
+		// Surface the backend logid to users via --envelope. The MCP server emits
+		// it as a "log_id: <id>" content entry, which mcpclient strips into
+		// Response.LogID (bare id, no prefix); without this hop into Metadata
+		// the id is silently dropped and oncall has no way to trace a specific
+		// call back to argos.
+		if logid := extractLogID(resp.LogID); logid != "" {
+			metadata["logid"] = logid
+		}
 		state.Result = &executor.RawResult{
-			Data: data,
-			Metadata: map[string]any{
-				"tool":        toolName,
-				"command":     strings.Join(state.Parsed.FullPath, " "),
-				"duration_ms": duration.Milliseconds(),
-			},
+			Data:     data,
+			Metadata: metadata,
 		}
 	}
 	return nil
+}
+
+// extractLogID returns the bare id for state.Metadata. mcpclient already
+// strips the "log_id:" / "logid:" prefix into Response.LogID, but we re-check
+// here as defense in depth — if a future code path forwards a raw-prefixed
+// string, we still surface a clean id instead of leaking the prefix into
+// --envelope's meta.
+func extractLogID(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	for _, p := range []string{"log_id:", "logid:"} {
+		if rest, ok := strings.CutPrefix(s, p); ok {
+			s = strings.TrimSpace(rest)
+			break
+		}
+	}
+	return s
 }
 
 func discoveryFailureCommandError(state *pipeline.PipelineContext) error {

--- a/internal/products/meegle/pipeline_test.go
+++ b/internal/products/meegle/pipeline_test.go
@@ -1034,6 +1034,124 @@ func TestMcpExecutorStep_DefaultUserAgentWhenUnset(t *testing.T) {
 	}
 }
 
+// When the backend returns a "log_id: <id>" content entry, McpExecutorStep
+// must surface it under Result.Metadata["logid"] so the EnvelopeHook can
+// expose it via --envelope. Without this, the id is silently dropped and
+// oncall has no way to trace a specific call back to argos. The production
+// server uses "log_id:" (with underscore); see mcpclient.logIDPrefixes for
+// the historical "logid:" alias.
+func TestMcpExecutorStep_PropagatesLogIDToMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ID int64 `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      body.ID,
+			"result": map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": "log_id: 20260519145706D6A0F7B0A114DB405B66"},
+					{"type": "text", "text": `{"ok":true}`},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	step := &McpExecutorStep{}
+	state := &pipeline.PipelineContext{
+		Parsed: &router.ParsedCommand{
+			FullPath: []string{"workitem", "get-brief"},
+			Node:     &registry.CommandNode{HandlerRef: "get_work_item"},
+			Flags:    map[string]any{},
+		},
+		Values: map[string]any{},
+		OutputConfig: map[string]any{
+			"mcp.host":       "ignored.example.com",
+			"mcp.server_url": server.URL,
+			"mcp.token":      "tok",
+			"mcp.headers":    map[string]string{},
+		},
+	}
+	if err := step.Execute(context.Background(), state); err != nil {
+		t.Fatalf("executor step failed: %v", err)
+	}
+	if state.Result == nil || state.Result.Metadata == nil {
+		t.Fatalf("expected Result with Metadata, got %+v", state.Result)
+	}
+	got, _ := state.Result.Metadata["logid"].(string)
+	if got != "20260519145706D6A0F7B0A114DB405B66" {
+		t.Errorf("expected logid metadata stripped of prefix, got %q", got)
+	}
+}
+
+// When the backend response carries no logid entry, Metadata must not
+// contain an empty logid key — otherwise --envelope output would show
+// {"logid":""} and mislead users into thinking they have a trace id.
+func TestMcpExecutorStep_OmitsLogIDWhenAbsent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ID int64 `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      body.ID,
+			"result": map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": `{"ok":true}`},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	step := &McpExecutorStep{}
+	state := &pipeline.PipelineContext{
+		Parsed: &router.ParsedCommand{
+			FullPath: []string{"workitem", "get-brief"},
+			Node:     &registry.CommandNode{HandlerRef: "get_work_item"},
+			Flags:    map[string]any{},
+		},
+		Values: map[string]any{},
+		OutputConfig: map[string]any{
+			"mcp.host":       "ignored.example.com",
+			"mcp.server_url": server.URL,
+			"mcp.token":      "tok",
+			"mcp.headers":    map[string]string{},
+		},
+	}
+	if err := step.Execute(context.Background(), state); err != nil {
+		t.Fatalf("executor step failed: %v", err)
+	}
+	if state.Result == nil {
+		t.Fatalf("expected Result, got nil")
+	}
+	if _, ok := state.Result.Metadata["logid"]; ok {
+		t.Errorf("expected no logid key in metadata when backend omitted it, got %+v", state.Result.Metadata)
+	}
+}
+
+func TestExtractLogID(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"abc123", "abc123"}, // bare id — what mcpclient now passes us
+		{"log_id: abc123", "abc123"},
+		{"log_id:abc123", "abc123"},
+		{"  log_id:   abc123  ", "abc123"},
+		{"logid: abc123", "abc123"}, // historical alias
+		{"logid:abc123", "abc123"},
+	}
+	for _, c := range cases {
+		if got := extractLogID(c.in); got != c.want {
+			t.Errorf("extractLogID(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 // SessionStep must translate ident.UserAgentCaller into the pre-built
 // "mcp.user_agent" key that newMcpClientFromState consumes. This pins the
 // startup → runtime handoff.

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",

--- a/skills/meegle/SKILL.md
+++ b/skills/meegle/SKILL.md
@@ -43,13 +43,26 @@ description: |
 | --ignore-role-calculate | boolean | 否 | 是否忽略角色计算；默认 false，谨慎使用 |
 
 ### workitem get
-按 ID/名称查询工作项概况。不传 fields 时仅返回固定基础字段；如需自定义字段数据，先调 `workitem meta-fields` 获取字段 key 后传入 fields。
+按 ID/名称查询工作项概况。不传 fields 时返回固定基础字段加上一组默认带出的系统字段——实测包含 `group_type` 拉群方式、`description`、`current_status_operator`、`watchers`（即便 value 为 null 也会出现）；其余字段需要通过 `workitem meta-fields` 拿到 key 后再传入 fields。
 
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | --work-item-id | string | 是 | 工作项 ID 或名称 |
 | --project-key | string | 否 | 空间 key |
-| --fields | array | 否 | 要查询的 field_key 或 field_name |
+| --fields | array | 否 | 要查询的 field_key 或 field_name；传 `["_all"]` 时按逻辑字段分页返回全部字段；传 `["group_type"]` 时只取拉群方式 |
+| --page-size | number | 否 | 仅 `fields=["_all"]` 时生效；每页字段数量，默认 100，最大 200。**meegle CLI 注意**：直接传 `--page-size N` 会被序列化成字符串触发后端 `need I64 type, but got: STRING`；当前只能走 `--params '{"page_size":N}'` 让它以数字传出 |
+| --page-token | string | 否 | 仅 `fields=["_all"]` 时生效；翻页 token，首次不传，下一页传上次响应的 `next_page_token`（token 形如字段 key，例如 `"business"`）；同上，meegle CLI 当前需要走 `--params '{"page_token":"..."}'` |
+
+> **逻辑字段聚合（重要心智模型）**：服务端把 `group_id` / `chat_group` 这类"拉群"相关的物理字段**合并**到一个逻辑字段 `group_type`。读取/更新统一走 `group_type`，**不要再单独读取 `group_id` 或 `chat_group`**。
+>
+> ⚠️ **读写协议不对称**：读返回结构里**判别键是 `value`**（不是 `type`），更新时**判别键是 `type`**——别照着读到的结构直接回写。
+>
+> 读返回（`workitem_fields[].value` 字段）的形状：
+> - `auto` → `{value: "auto", label: "自动拉群", group_id: "oc_xxx"}`（自动拉群通常有 group_id；状态切换时 oc_id 可能会变）
+> - `bind` → `{value: "bind", label: "绑定现有群", group_id: "oc_xxx"}`
+> - `disabled` → `{value: "disabled", label: "不拉群"}`（无 group_id）
+>
+> 写协议（`field_value` 里的 JSON）：`{"type": "auto" | "bind" | "disabled", "group_id": "oc_xxx"}`
 
 ### workitem batch-get
 批量查询工作项（Meegle CLI 客户端 fan-out：并发调用 `workitem get`）。单次 ≤ 200 个 ID，3 并发，返回 `{results, errors, summary}`；ID 量大时用 `--format ndjson` 流式输出。
@@ -72,6 +85,8 @@ description: |
 | --role-operate | array | 否 | 角色操作，每项含 op(add/remove)、role_key、user_keys |
 
 **角色更新**：不能通过 fields 更新角色，必须用 `role_operate`。role_key 通过 `workitem meta-roles` 获取，user_keys 通过 `user search` 获取。
+
+**拉群方式更新（`group_type` 逻辑字段）**：要修改/读取拉群方式统一走 `group_type`，不要再单独操作 `group_id` / `chat_group`。写协议 `field_value` 形如：`{"type": "auto" | "bind" | "disabled", "group_id": "oc_xxx"}`（注意写用 `type` 作为判别键，**与读返回的 `value` 不对称**）。校验规则（服务端实际报错文本）：`bind` 不带 `group_id` 或带空串/纯空格 → `group_id is required when group_type=bind`；`auto`/`disabled` 同时带 `group_id` → `group_type conflicts with group_id: type=<auto|disabled>`。详细示例见 [references/sop-update-workitem.md](references/sop-update-workitem.md)。
 
 ### workitem query
 使用 MQL 查询工作项数据。语法详见 [references/mql-syntax.md](references/mql-syntax.md)。

--- a/skills/meegle/references/api-examples.md
+++ b/skills/meegle/references/api-examples.md
@@ -60,6 +60,21 @@ meegle workitem query --project-key 空间key --session-id 上次返回的sessio
 meegle workitem get --work-item-id 工作项ID或名称 --fields '{{fields}}' --project-key 空间key --format json
 ```
 
+只取拉群方式（`group_type` 逻辑字段，聚合自 `group_id` / `chat_group`）：
+
+```bash
+meegle workitem get --work-item-id 工作项ID --fields '["group_type"]' --project-key 空间key --format json
+```
+
+全量字段分页（`fields=["_all"]` 时按逻辑字段分页，`page_size` 默认 100，最大 200；下一页用上次响应的 `next_page_token` 传 `page_token`，token 形如字段 key 如 `"business"`）：
+
+⚠️ meegle CLI 当前 `--page-size` / `--page-token` flag 会被序列化成字符串触发后端 `need I64 type, but got: STRING`；当前可用的写法是通过 `--params` 把整数传出去——
+
+```bash
+meegle workitem get --work-item-id 工作项ID --project-key 空间key --fields '["_all"]' --params '{"page_size":100}' --format json
+meegle workitem get --work-item-id 工作项ID --project-key 空间key --fields '["_all"]' --params '{"page_size":100,"page_token":"<next_page_token>"}' --format json
+```
+
 ### workitem create
 基础创建（仅标量字段）：
 
@@ -92,6 +107,26 @@ meegle workitem update --work-item-id 工作项ID --project-key 空间key --role
 
 ```bash
 meegle workitem update --work-item-id 工作项ID --project-key 空间key --role-operate '{{role_operate}}' --fields '[{"field_key": "current_status_operator", "field_value": "["userkey1","userkey2"]"}]' --format json
+```
+
+更新拉群方式（`group_type` 逻辑字段，统一替代旧 `group_id` / `chat_group`）——三种形态：
+
+切到自动拉群（不带 `group_id`）：
+
+```bash
+meegle workitem update --work-item-id 工作项ID --project-key 空间key --role-operate '{{role_operate}}' --fields '[{"field_key":"group_type","field_value":"{"type":"auto"}"}]' --format json
+```
+
+绑定现有群（`type=bind` 必须带非空 `group_id`）：
+
+```bash
+meegle workitem update --work-item-id 工作项ID --project-key 空间key --role-operate '{{role_operate}}' --fields '[{"field_key":"group_type","field_value":"{"type":"bind","group_id":"oc_xxx"}"}]' --format json
+```
+
+关闭拉群：
+
+```bash
+meegle workitem update --work-item-id 工作项ID --project-key 空间key --role-operate '{{role_operate}}' --fields '[{"field_key":"group_type","field_value":"{"type":"disabled"}"}]' --format json
 ```
 
 ---

--- a/skills/meegle/references/error-handling.md
+++ b/skills/meegle/references/error-handling.md
@@ -28,4 +28,7 @@ SKILL.md 主文件已经收录错误处理总则与熔断条件，本文件提�
 | 节点流转失败 | 节点流用 `workflow transition`；状态流用 `workflow transition-state`（先 `workflow list-state-transitions` 取 transition_id，再 `workflow list-state-required` 查必填项） |
 | 创建工作项缺少模板 | `workitem meta-fields(field_keys=["template"])` 获取 |
 | 角色更新失败 | 改用 `workitem update` 的 `role_operate` 参数（不走 fields） |
+| `group_id is required when group_type=bind` | 更新 `group_type` 时 `type=bind` 必须带 `group_id`，并且不能是空串或纯空格；改成 `{"type":"bind","group_id":"oc_xxx"}` 后重试。要解绑群改用 `{"type":"disabled"}` |
+| `group_type conflicts with group_id: type=<auto|disabled>` | 同时传了 `type=auto` 或 `type=disabled` 又带了 `group_id`；保留 `type=bind` + `group_id`，或去掉 `group_id` 后重试 |
+| `need I64 type, but got: STRING`（page_size / page_token） | `page_size` 被当成字符串传出；meegle CLI 改用 `--params '{"page_size":N,"page_token":"<token>"}'` 让数字以 JSON number 传出 |
 | mywork.todo 需选择工作区 | 按报错中的列表把 `asset_key`（Asset_xxx）传入重试 |

--- a/skills/meegle/references/sop-update-workitem.md
+++ b/skills/meegle/references/sop-update-workitem.md
@@ -66,6 +66,26 @@ meegle workitem update --work-item-id 工作项ID --project-key 空间key --role
 [{"op": "add", "role_key": "角色key", "user_keys": ["userkey1"]}]
 ```
 
+**拉群方式更新（`group_type` 逻辑字段）**：服务端把 `group_id` / `chat_group` 合并到 `group_type` 单字段，统一通过它读写——**禁止再单独写 `group_id` / `chat_group`**。写协议 `field_value`：
+
+```json
+{"type": "auto" | "bind" | "disabled", "group_id": "oc_xxx"}
+```
+
+⚠️ **读写不对称**：读返回的判别键是 `value`（如 `{"value":"auto","label":"自动拉群","group_id":"oc_xxx"}`），写要求的判别键是 `type`。不能直接把读到的结构丢回 update。
+
+| `type` | 含义 | 是否带 `group_id` | 客户端预校验 |
+|---|---|---|---|
+| `auto` | 自动拉群 | 不允许 | 带了 → 阻断（服务端会回 `group_type conflicts with group_id: type=auto`） |
+| `bind` | 绑定现有群 | **必填**，非空 `oc_xxx`（空串/纯空格也算缺失） | 缺失或全空白 → 阻断（服务端会回 `group_id is required when group_type=bind`） |
+| `disabled` | 不拉群 | 不允许 | 带了 → 阻断（服务端会回 `group_type conflicts with group_id: type=disabled`） |
+
+写法示例（详见 [api-examples.md](api-examples.md) 工作项域）：
+
+```bash
+meegle workitem update --work-item-id 工作项ID --project-key 空间key --role-operate '{{role_operate}}' --fields '[{"field_key":"group_type","field_value":"{"type":"bind","group_id":"oc_xxx"}"}]' --format json
+```
+
 ### STEP 5 — 返回结果
 
 展示修改了哪些字段及修改后的值。


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.