### PR TITLE
feat: verify attachment file integrity on +download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.9] - 2026-06-11
+
+### Added
+
+- `attachment +download` now performs an extra integrity check on the downloaded file and aborts — writing nothing to disk — when the file fails validation or cannot be verified. A failed check returns a `CLIENT_FILE_SIGN_MISMATCH` error and an unverifiable response returns `CLIENT_FILE_SIGN_UNVERIFIED`; both carry a retry hint.
+
 ## [v1.0.8] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -474,6 +474,18 @@ meegle attachment +download "$URL" \
   --output ./local.pdf --overwrite
 ```
 
+**Integrity check (`+download`)**: `+download` performs an extra integrity check
+on each downloaded file and aborts — writing nothing — if the file fails
+validation or cannot be verified. On a failed check you get a
+`CLIENT_FILE_SIGN_MISMATCH` error (unverifiable response →
+`CLIENT_FILE_SIGN_UNVERIFIED`); both are transient, so just retry.
+
+**Custom headers / env routing**: any custom headers configured for the active
+profile are applied to the download GET as well as the preprocess call, so an
+environment-routing header pins the whole download to the same environment. Auth
+headers are stripped before the GET so the token never reaches the
+object-storage host.
+
 `+upload` returns a JSON object with the file token and metadata:
 
 ```json

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -468,6 +468,15 @@ meegle attachment +download "$URL" \
   --output ./local.pdf --overwrite
 ```
 
+**完整性校验（`+download`）**：`+download` 会对下载的文件做一次额外的完整性校验，
+若校验失败或无法校验则中止下载、不写任何文件。校验不通过时返回
+`CLIENT_FILE_SIGN_MISMATCH` 错误（无法校验时为 `CLIENT_FILE_SIGN_UNVERIFIED`）；
+两者都是临时问题，重试即可。
+
+**自定义头 / 环境路由**：当前 profile 配置的自定义头会同时作用于下载 GET 与预处理调用，
+从而用环境路由头把整条下载固定到同一环境。GET 前会剥掉 auth 相关头，
+确保 token 不会发到对象存储所在的主机。
+
 `+upload` 输出 JSON 对象，包含 file_token 与文件元信息：
 
 ```json

--- a/internal/products/meegle/attachment/download.go
+++ b/internal/products/meegle/attachment/download.go
@@ -6,6 +6,7 @@ package attachment
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -13,6 +14,15 @@ import (
 	"os"
 	"strconv"
 	"strings"
+)
+
+// ErrFileSignMissing and ErrFileSignMismatch report failures of the file
+// signature integrity guard performed during +download (see verifySign). They
+// are exported so the register layer can errors.Is them — across the multipart
+// wrap — and map them to a user-facing CLIENT_* error with a retry hint.
+var (
+	ErrFileSignMissing  = errors.New("download response missing file signature header")
+	ErrFileSignMismatch = errors.New("download response file signature does not match the requested signature")
 )
 
 // DownloadPreprocess is the parsed result of the get_download_url MCP tool —
@@ -109,7 +119,7 @@ func ExecuteDownload(ctx context.Context, doer HTTPDoer, pre *DownloadPreprocess
 
 	if !pre.IsMultipart {
 		url := strings.ReplaceAll(pre.DownloadURL, partNumberPlaceholder, "0")
-		meta, err := doDownloadPart(ctx, doer, url, pre.Sign, partial)
+		meta, err := doDownloadPart(ctx, doer, url, pre.Sign, in.Headers, partial)
 		if err != nil {
 			cleanup()
 			return nil, err
@@ -120,7 +130,7 @@ func ExecuteDownload(ctx context.Context, doer HTTPDoer, pre *DownloadPreprocess
 	} else {
 		for i := int32(0); i < pre.Multipart.PartCount; i++ {
 			url := strings.ReplaceAll(pre.DownloadURL, partNumberPlaceholder, strconv.Itoa(int(i)))
-			meta, err := doDownloadPart(ctx, doer, url, pre.Sign, partial)
+			meta, err := doDownloadPart(ctx, doer, url, pre.Sign, in.Headers, partial)
 			if err != nil {
 				cleanup()
 				return nil, fmt.Errorf("download chunk %d: %w", i, err)
@@ -207,10 +217,15 @@ type partMeta struct {
 	mimeType string
 }
 
-func doDownloadPart(ctx context.Context, doer HTTPDoer, url, sign string, sink io.Writer) (*partMeta, error) {
+func doDownloadPart(ctx context.Context, doer HTTPDoer, url, sign string, extraHeaders map[string]string, sink io.Writer) (*partMeta, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
+	}
+	// Caller-supplied headers first (e.g. environment-routing headers); the
+	// signature header is set last so it can never be clobbered.
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
 	}
 	req.Header.Set(signHeader, sign)
 	resp, err := doer.Do(req)
@@ -221,6 +236,12 @@ func doDownloadPart(ctx context.Context, doer HTTPDoer, url, sign string, sink i
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("download part HTTP %d", resp.StatusCode)
 	}
+	// Integrity guard before reading the body: abort if the echoed signature
+	// doesn't match the one we requested, so a mis-served object is never
+	// written.
+	if err := verifySign(resp.Header.Get(signHeader), sign); err != nil {
+		return nil, err
+	}
 	n, err := io.Copy(sink, resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("write part body: %w", err)
@@ -230,6 +251,23 @@ func doDownloadPart(ctx context.Context, doer HTTPDoer, url, sign string, sink i
 		name:     filenameFromHeader(resp.Header.Get("Content-Disposition")),
 		mimeType: resp.Header.Get("Content-Type"),
 	}, nil
+}
+
+// verifySign enforces the CDN-cache integrity guard: the backend echoes the
+// per-request signature on every download response, and the +download flow
+// only writes bytes whose echoed signature matches the one we requested. Both
+// a missing header (can't verify) and a mismatch are fail-closed — they abort
+// the download so a mis-served object never reaches disk. The comparison is
+// case-insensitive, matching the header's case-insensitive contract.
+func verifySign(got, want string) error {
+	got = strings.TrimSpace(got)
+	if got == "" {
+		return fmt.Errorf("%w (%s)", ErrFileSignMissing, signHeader)
+	}
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("%w: response signature %q, requested %q", ErrFileSignMismatch, got, want)
+	}
+	return nil
 }
 
 // filenameFromHeader extracts the filename from a Content-Disposition header.

--- a/internal/products/meegle/attachment/download_test.go
+++ b/internal/products/meegle/attachment/download_test.go
@@ -6,6 +6,7 @@ package attachment_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -47,6 +48,7 @@ func TestDownloadFlow_OneShot(t *testing.T) {
 		gotSign = r.Header.Get("X-Meego-File-Sign")
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Content-Disposition", `attachment; filename="server.txt"`)
+		w.Header().Set("X-Meego-File-Sign", "SIGN-DL")
 		w.WriteHeader(200)
 		_, _ = w.Write(payload)
 	}))
@@ -110,6 +112,7 @@ func TestDownloadFlow_Multipart_ConcatenatesParts(t *testing.T) {
 		parts := strings.Split(r.URL.Path, "/")
 		last := parts[len(parts)-1]
 		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("X-Meego-File-Sign", "S")
 		w.WriteHeader(200)
 		switch last {
 		case "0":
@@ -174,6 +177,7 @@ func TestDownloadFlow_ExistingOutput_NoOverwrite(t *testing.T) {
 
 func TestDownloadFlow_ExistingOutput_WithOverwrite(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Meego-File-Sign", "S")
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte("new contents"))
 	}))
@@ -228,6 +232,170 @@ func TestDownloadFlow_HTTP404_CleansUpPartial(t *testing.T) {
 	}
 	if _, e := os.Stat(output + ".partial"); !os.IsNotExist(e) {
 		t.Errorf(".partial should be cleaned up after failed download")
+	}
+}
+
+func TestDownloadFlow_FileSignMismatch_Aborts(t *testing.T) {
+	// Integrity guard: the response echoes a signature that doesn't match the
+	// one we requested (cache served the wrong object), so the download must
+	// abort fail-closed and leave nothing behind.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Meego-File-Sign", "WRONG")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("the wrong object"))
+	}))
+	defer ts.Close()
+
+	mcp := &fakeMCP{response: &attachment.MCPResponse{Data: map[string]any{
+		"sign": "S", "is_multipart": false,
+		"download_url": ts.URL + "/:part_number",
+	}}}
+	tmpDir := t.TempDir()
+	output := filepath.Join(tmpDir, "wrong-object.txt")
+
+	_, err := downloadFull(t, mcp, http.DefaultClient, attachment.DownloadInput{
+		ProjectKey: "P", WorkItemID: "W", FileURL: "x", Output: output,
+	})
+	if !errors.Is(err, attachment.ErrFileSignMismatch) {
+		t.Fatalf("want ErrFileSignMismatch, got %v", err)
+	}
+	if _, e := os.Stat(output); !os.IsNotExist(e) {
+		t.Errorf("output should not exist after mismatch abort")
+	}
+	if _, e := os.Stat(output + ".partial"); !os.IsNotExist(e) {
+		t.Errorf(".partial should be cleaned up after mismatch abort")
+	}
+}
+
+func TestDownloadFlow_FileSignCaseInsensitive_Succeeds(t *testing.T) {
+	// The signature comparison is case-insensitive: a response echoing the sign
+	// in a different case must still be accepted.
+	payload := []byte("case folded ok")
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Meego-File-Sign", "sign-dl")
+		w.WriteHeader(200)
+		_, _ = w.Write(payload)
+	}))
+	defer ts.Close()
+
+	mcp := &fakeMCP{response: &attachment.MCPResponse{Data: map[string]any{
+		"sign": "SIGN-DL", "is_multipart": false,
+		"download_url": ts.URL + "/:part_number",
+	}}}
+	tmpDir := t.TempDir()
+	output := filepath.Join(tmpDir, "folded.txt")
+
+	result, err := downloadFull(t, mcp, http.DefaultClient, attachment.DownloadInput{
+		ProjectKey: "P", WorkItemID: "W", FileURL: "x", Output: output,
+	})
+	if err != nil {
+		t.Fatalf("case-insensitive sign should be accepted: %v", err)
+	}
+	if result.Size != int64(len(payload)) {
+		t.Errorf("Size=%d, want %d", result.Size, len(payload))
+	}
+}
+
+func TestDownloadFlow_MissingFileSignHeader_Aborts(t *testing.T) {
+	// Fail-closed: a response with no signature header can't be verified, so the
+	// download aborts rather than trusting an unverified object.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("unverifiable object"))
+	}))
+	defer ts.Close()
+
+	mcp := &fakeMCP{response: &attachment.MCPResponse{Data: map[string]any{
+		"sign": "S", "is_multipart": false,
+		"download_url": ts.URL + "/:part_number",
+	}}}
+	tmpDir := t.TempDir()
+	output := filepath.Join(tmpDir, "unverified.txt")
+
+	_, err := downloadFull(t, mcp, http.DefaultClient, attachment.DownloadInput{
+		ProjectKey: "P", WorkItemID: "W", FileURL: "x", Output: output,
+	})
+	if !errors.Is(err, attachment.ErrFileSignMissing) {
+		t.Fatalf("want ErrFileSignMissing, got %v", err)
+	}
+	if _, e := os.Stat(output + ".partial"); !os.IsNotExist(e) {
+		t.Errorf(".partial should be cleaned up after missing-header abort")
+	}
+}
+
+func TestDownloadFlow_Multipart_PartMismatch_Aborts(t *testing.T) {
+	// First part echoes the right signature, second part echoes a wrong one
+	// (cache poisoned mid-stream). The guard must fire on the bad part and the
+	// mismatch must survive the multipart error wrap so errors.Is still matches.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		last := parts[len(parts)-1]
+		switch last {
+		case "0":
+			w.Header().Set("X-Meego-File-Sign", "S")
+		default:
+			w.Header().Set("X-Meego-File-Sign", "WRONG")
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("chunk"))
+	}))
+	defer ts.Close()
+
+	mcp := &fakeMCP{response: &attachment.MCPResponse{Data: map[string]any{
+		"sign": "S", "is_multipart": true,
+		"download_url": ts.URL + "/dl/:part_number",
+		"multipart":    map[string]any{"part_count": 2, "part_size": 5},
+	}}}
+	tmpDir := t.TempDir()
+	output := filepath.Join(tmpDir, "poisoned.bin")
+
+	_, err := downloadFull(t, mcp, http.DefaultClient, attachment.DownloadInput{
+		ProjectKey: "P", WorkItemID: "W", FileURL: "x", Output: output,
+	})
+	if !errors.Is(err, attachment.ErrFileSignMismatch) {
+		t.Fatalf("want ErrFileSignMismatch through multipart wrap, got %v", err)
+	}
+	if _, e := os.Stat(output); !os.IsNotExist(e) {
+		t.Errorf("output should not exist after multipart mismatch abort")
+	}
+	if _, e := os.Stat(output + ".partial"); !os.IsNotExist(e) {
+		t.Errorf(".partial should be cleaned up after multipart mismatch abort")
+	}
+}
+
+func TestDownloadFlow_ForwardsExtraHeaders(t *testing.T) {
+	// Caller-supplied headers (e.g. lane routing) must reach the GET, and must
+	// not be able to clobber the signature header.
+	var gotEnv, gotSign string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEnv = r.Header.Get("X-Custom-Env")
+		gotSign = r.Header.Get("X-Meego-File-Sign")
+		w.Header().Set("X-Meego-File-Sign", "S")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	mcp := &fakeMCP{response: &attachment.MCPResponse{Data: map[string]any{
+		"sign": "S", "is_multipart": false,
+		"download_url": ts.URL + "/:part_number",
+	}}}
+	tmpDir := t.TempDir()
+	output := filepath.Join(tmpDir, "with-headers.txt")
+
+	_, err := downloadFull(t, mcp, http.DefaultClient, attachment.DownloadInput{
+		ProjectKey: "P", WorkItemID: "W", FileURL: "x", Output: output,
+		// The bogus signature here must lose to the real one set by the flow.
+		Headers: map[string]string{"x-custom-env": "lane-1", "X-Meego-File-Sign": "HACK"},
+	})
+	if err != nil {
+		t.Fatalf("downloadFull: %v", err)
+	}
+	if gotEnv != "lane-1" {
+		t.Errorf("x-custom-env=%q, want lane-1 (extra header not forwarded)", gotEnv)
+	}
+	if gotSign != "S" {
+		t.Errorf("sign header=%q, want S (extra header must not clobber the signature)", gotSign)
 	}
 }
 

--- a/internal/products/meegle/attachment/preprocess_test.go
+++ b/internal/products/meegle/attachment/preprocess_test.go
@@ -201,6 +201,7 @@ func TestExecuteDownload_RequiresOutput(t *testing.T) {
 func TestExecuteDownload_OneShot_NoMCP(t *testing.T) {
 	payload := []byte("file contents")
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Meego-File-Sign", "S")
 		w.WriteHeader(200)
 		_, _ = w.Write(payload)
 	}))

--- a/internal/products/meegle/attachment/types.go
+++ b/internal/products/meegle/attachment/types.go
@@ -106,6 +106,13 @@ type DownloadInput struct {
 	FileURL    string // opaque reference received from another MCP tool
 	Output     string // local destination path
 	Overwrite  bool
+	// Headers are extra HTTP headers set on each object-storage GET — used to
+	// carry environment / lane routing headers so a download can be pinned to
+	// the same lane as the preprocess call. The caller is
+	// responsible for stripping auth-bearing headers so the Meegle token is
+	// never leaked to the object-storage host. The signature header always
+	// takes precedence over anything supplied here.
+	Headers map[string]string
 }
 
 // DownloadResult is returned on success. Name / MimeType are best-effort from
@@ -122,6 +129,13 @@ type DownloadResult struct {
 // keeps the two flows in sync if the backend ever changes the placeholder.
 const partNumberPlaceholder = ":part_number"
 
-// signHeader is the HTTP header carrying the per-request signature returned
-// by the MCP preprocess tool. Used by both upload and download flows.
+// signHeader is the HTTP header carrying the per-request signature returned by
+// the MCP preprocess tool. The upload and download flows send it on each
+// object-storage request; on download the backend also echoes it back on the
+// response, and +download compares the echoed value against the requested
+// signature to verify the file's correctness — guarding against a CDN cache
+// occasionally serving the wrong object. The guard is fail-closed: a missing
+// or mismatched header aborts the download before any bytes reach the
+// destination. HTTP header names are case-insensitive (http.Header.Get
+// canonicalises), and the value is compared case-insensitively too.
 const signHeader = "X-Meego-File-Sign"

--- a/internal/products/meegle/attachment_error_test.go
+++ b/internal/products/meegle/attachment_error_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package meegle
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/meegle-cli/internal/products/meegle/attachment"
+	meerrors "github.com/larksuite/meegle-cli/internal/products/meegle/errors"
+	"github.com/larksuite/meegle-cli/pkg/framework/pipeline"
+)
+
+// TestMapDownloadError pins the contract the +download integrity guard exposes
+// to users: the attachment package's internal sentinels must surface as the
+// documented CLIENT_* codes and carry a retry hint. Unrelated errors must pass
+// through untouched. The mismatch case is fed through a wrap to prove errors.Is
+// still matches across the multipart error wrapping ExecuteDownload applies.
+func TestMapDownloadError(t *testing.T) {
+	passthrough := errors.New("some unrelated download failure")
+
+	cases := []struct {
+		name     string
+		in       error
+		wantCode string // "" → expect the original error back, unchanged
+	}{
+		{
+			name:     "mismatch maps to CLIENT_FILE_SIGN_MISMATCH (through wrap)",
+			in:       fmt.Errorf("download chunk 1: %w", attachment.ErrFileSignMismatch),
+			wantCode: "CLIENT_FILE_SIGN_MISMATCH",
+		},
+		{
+			name:     "missing header maps to CLIENT_FILE_SIGN_UNVERIFIED",
+			in:       attachment.ErrFileSignMissing,
+			wantCode: "CLIENT_FILE_SIGN_UNVERIFIED",
+		},
+		{
+			name:     "unrelated error passes through unchanged",
+			in:       passthrough,
+			wantCode: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mapDownloadError(c.in)
+
+			if c.wantCode == "" {
+				if got != c.in {
+					t.Fatalf("passthrough: got %v, want the original error unchanged", got)
+				}
+				return
+			}
+
+			var me *meerrors.MeegleError
+			if !errors.As(got, &me) {
+				t.Fatalf("want *MeegleError, got %T (%v)", got, got)
+			}
+			if me.Code != c.wantCode {
+				t.Errorf("Code = %q, want %q", me.Code, c.wantCode)
+			}
+			if !strings.Contains(strings.ToLower(me.Suggestion), "retry") {
+				t.Errorf("Suggestion = %q, want it to prompt a retry", me.Suggestion)
+			}
+		})
+	}
+}
+
+// TestDownloadGETHeaders pins the safety contract of the download GET header
+// forwarding: configured lane/env headers flow through, but auth-bearing
+// headers are stripped so the Meegle token never reaches the object-storage
+// host.
+func TestDownloadGETHeaders(t *testing.T) {
+	state := &pipeline.PipelineContext{
+		OutputConfig: map[string]any{
+			"mcp.headers": map[string]string{
+				"x-custom-env":  "lane-1",
+				"x-route":       "1",
+				"Authorization": "Bearer super-secret",
+				"X-Token":       "tok-123",
+			},
+			"mcp.access_token_header": "X-Token",
+		},
+	}
+
+	got := downloadGETHeaders(state)
+
+	if got["x-custom-env"] != "lane-1" || got["x-route"] != "1" {
+		t.Errorf("custom headers should be forwarded, got %v", got)
+	}
+	if _, ok := got["Authorization"]; ok {
+		t.Error("Authorization must be stripped (token leak)")
+	}
+	if _, ok := got["X-Token"]; ok {
+		t.Error("the configured access-token header must be stripped (token leak)")
+	}
+}
+
+func TestDownloadGETHeaders_NilWhenEmpty(t *testing.T) {
+	if got := downloadGETHeaders(&pipeline.PipelineContext{OutputConfig: map[string]any{}}); got != nil {
+		t.Errorf("want nil when no headers configured, got %v", got)
+	}
+	// Only auth headers configured → nothing forwardable → nil.
+	state := &pipeline.PipelineContext{OutputConfig: map[string]any{
+		"mcp.headers":             map[string]string{"Authorization": "Bearer x"},
+		"mcp.access_token_header": "",
+	}}
+	if got := downloadGETHeaders(state); got != nil {
+		t.Errorf("want nil when only auth headers present, got %v", got)
+	}
+}

--- a/internal/products/meegle/attachment_register.go
+++ b/internal/products/meegle/attachment_register.go
@@ -5,11 +5,13 @@ package meegle
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/larksuite/meegle-cli/pkg/framework/executor"
 	"github.com/larksuite/meegle-cli/pkg/framework/pipeline"
@@ -349,6 +351,7 @@ func (s *AttachmentShortcutStep) runDownload(ctx context.Context, state *pipelin
 		FileURL:    fileURL,
 		Output:     stringFlag(state, "output"),
 		Overwrite:  boolFlag(state, "overwrite"),
+		Headers:    downloadGETHeaders(state),
 	}
 
 	mcp := s.resolveClient(state)
@@ -363,11 +366,59 @@ func (s *AttachmentShortcutStep) runDownload(ctx context.Context, state *pipelin
 	}
 	result, err := attachment.ExecuteDownload(ctx, doer, pre, in)
 	if err != nil {
-		return err
+		return mapDownloadError(err)
 	}
 
 	state.Result = &executor.RawResult{Data: result}
 	return nil
+}
+
+// mapDownloadError translates the attachment package's file-signature integrity
+// guard failures into a user-facing CLIENT_* error with a retry hint. The bug
+// it guards against — a CDN cache occasionally serving the wrong object —
+// usually clears on retry, so both variants steer the user to re-run the
+// command. Any other error passes through unchanged.
+func mapDownloadError(err error) error {
+	switch {
+	case stderrors.Is(err, attachment.ErrFileSignMismatch):
+		return meerrors.NewClientError("CLIENT_FILE_SIGN_MISMATCH",
+			fmt.Sprintf("downloaded file failed its integrity check (%v); download failed", err)).
+			WithSuggestion("The download returned content for a different signature, likely a stale CDN cache. Please retry `meegle attachment +download`.")
+	case stderrors.Is(err, attachment.ErrFileSignMissing):
+		return meerrors.NewClientError("CLIENT_FILE_SIGN_UNVERIFIED",
+			fmt.Sprintf("cannot verify the downloaded file's integrity (%v); download failed", err)).
+			WithSuggestion("The download response did not include the signature header needed to verify the file. Please retry `meegle attachment +download`.")
+	default:
+		return err
+	}
+}
+
+// downloadGETHeaders returns the profile's configured custom headers for use on
+// the object-storage download GET, with auth-bearing headers stripped so the
+// Meegle token is never leaked to that host. This lets environment / lane
+// routing headers configured for the MCP calls also pin the download GET to the
+// same lane. Mirrors the auth-stripping in newMcpClientFromState. Returns nil
+// when nothing forwardable remains.
+func downloadGETHeaders(state *pipeline.PipelineContext) map[string]string {
+	hdrs, _ := state.OutputConfig["mcp.headers"].(map[string]string)
+	if len(hdrs) == 0 {
+		return nil
+	}
+	authHeader, _ := state.OutputConfig["mcp.access_token_header"].(string)
+	out := make(map[string]string, len(hdrs))
+	for k, v := range hdrs {
+		if strings.EqualFold(k, "Authorization") {
+			continue
+		}
+		if authHeader != "" && strings.EqualFold(k, authHeader) {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // resolveClient returns the test-injected MCPClient or, in production, wraps

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",


### PR DESCRIPTION
Adds an integrity check to `attachment +download`: the command now verifies each downloaded file and aborts — writing nothing to disk — when the file fails validation or cannot be verified. A failed check returns a `CLIENT_FILE_SIGN_MISMATCH` error and an unverifiable response returns `CLIENT_FILE_SIGN_UNVERIFIED`; both carry a retry hint.

Bumps the version to 1.0.9.
