### PR TITLE
fix: skip startup tool discovery for offline commands

### DIFF
--- a/internal/products/meegle/app.go
+++ b/internal/products/meegle/app.go
@@ -64,18 +64,51 @@ type StaticCommands struct {
 	URL        *cobra.Command
 }
 
+// offlineCommands are top-level commands that don't need the dynamically
+// discovered tool tree, so NewCLIApp skips startup MCP discovery for them.
+// `completion` is the key case: shell rc files run `meegle completion zsh` on
+// every new shell, where a discovery round-trip would stall startup. (auth
+// still makes its own token calls at run time; only tree discovery is skipped.)
+// Excluded — they need or show the tree: help, inspect, the runtime
+// __complete, and all business commands.
+var offlineCommands = map[string]bool{
+	"completion": true,
+	"auth":       true,
+	"config":     true,
+	"url":        true,
+	"version":    true,
+}
+
+// isOfflineCommand reports whether argv invokes an offlineCommands entry. Keyed
+// on args[0]: leading global flags (e.g. `--profile p config get`) fall through
+// to discovery — at worst one redundant lookup, never a missing tree.
+func isOfflineCommand(args []string) bool {
+	return len(args) > 0 && offlineCommands[args[0]]
+}
+
 // NewCLIApp assembles the meegle CLI application, injecting the four customization points.
 // staticCmds are optional static subcommands (auth/config/inspect) used to break circular dependencies.
 func NewCLIApp(version string, staticCmds *StaticCommands) (*cliapp.App, error) {
-	// 1. Load default configuration (graceful: use empty config on failure)
-	profileName, _ := GetCurrentProfileName()
-	cfg, _ := LoadConfig(profileName)
+	// Skip identity resolution + MCP discovery for commands that need only the
+	// static command set — chiefly `completion`, re-run on every shell startup.
+	skipDiscovery := isOfflineCommand(os.Args[1:])
 
-	// 2. Build MCP client (if host + token are configured)
-	client, ident := buildMcpClient(cfg, profileName)
+	var (
+		client *mcpclient.Client
+		ident  ResolvedIdentity
+		cache  *ToolCache
+	)
+	if !skipDiscovery {
+		// 1. Load default configuration (graceful: use empty config on failure)
+		profileName, _ := GetCurrentProfileName()
+		cfg, _ := LoadConfig(profileName)
 
-	// 3. Build ToolCache
-	cache := NewToolCache(GetCacheDir(), profileName, DefaultTTL)
+		// 2. Build MCP client (if host + token are configured)
+		client, ident = buildMcpClient(cfg, profileName)
+
+		// 3. Build ToolCache
+		cache = NewToolCache(GetCacheDir(), profileName, DefaultTTL)
+	}
 
 	// 4. Create DynamicRegistrySetup (client may be nil; avoid the typed nil interface pitfall)
 	var lister discovery.ToolLister

--- a/internal/products/meegle/app_test.go
+++ b/internal/products/meegle/app_test.go
@@ -8,6 +8,48 @@ import (
 	"testing"
 )
 
+// isOfflineCommand gates the startup discovery skip: offline commands must
+// match; tree-dependent ones (help, inspect, runtime __complete, business
+// commands) must not.
+func TestIsOfflineCommand(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		// completion — the hot path (re-run on every new shell).
+		{"completion zsh", []string{"completion", "zsh"}, true},
+		{"completion bash", []string{"completion", "bash"}, true},
+		{"completion fish", []string{"completion", "fish"}, true},
+		{"completion install", []string{"completion", "install"}, true},
+		{"completion trailing args", []string{"completion", "zsh", "--no-descriptions"}, true},
+		// no/invalid shell still skips: the command errors on its own args.
+		{"completion no shell", []string{"completion"}, true},
+		{"completion unknown shell", []string{"completion", "powershell"}, true},
+		// other offline commands
+		{"auth login", []string{"auth", "login"}, true},
+		{"config get", []string{"config", "get", "host"}, true},
+		{"url decode", []string{"url", "decode", "https://example"}, true},
+		{"version", []string{"version"}, true},
+		// must not match — these need the tree
+		{"runtime __complete", []string{"__complete", "workitem", ""}, false},
+		{"top-level help flag", []string{"--help"}, false},
+		{"help command", []string{"help"}, false},
+		{"inspect", []string{"inspect", "workitem.create"}, false},
+		{"business command", []string{"workitem", "create"}, false},
+		{"empty", nil, false},
+		// leading flags fall through to discovery
+		{"flag before command", []string{"--profile", "x", "config", "get"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isOfflineCommand(tc.args); got != tc.want {
+				t.Errorf("isOfflineCommand(%q) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildRegistrySetup_NilHeaders(t *testing.T) {
 	setup := BuildRegistrySetup("example.com", nil)
 	if setup == nil {


### PR DESCRIPTION
`meegle completion zsh` is installed into shell rc files via `source <(meegle completion zsh)`, so it runs on every new shell. The generated completion script is a generic cobra template that delegates to `meegle __complete` at runtime, so it does not depend on the dynamically discovered command tree. Yet NewCLIApp ran MCP tool discovery unconditionally at startup (timeout-less http.DefaultClient + context.Background), stalling — or hanging — shell startup on a cold/stale cache or when offline.

Add an offlineCommands allowlist (completion, auth, config, url, version): top-level commands that don't need the discovered tool tree. For these, skip identity resolution + MCP discovery. Tree-dependent paths (help, inspect, the runtime __complete, and business commands) are unaffected.