### PR TITLE
fix: restore npx install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.14] - 2026-07-01
+
+### Fixed
+
+- Restored the valid npm quick-start command to `npx @lark-project/meegle@latest install`. `npx @lark-project/meegle@latest` already invokes the package's `meegle` binary, so appending `meegle install` passes an invalid extra `meegle` subcommand to the CLI.
+
 ## [v1.0.13] - 2026-06-30
 
 ### Fixed
 
-- Corrected the npm quick-start commands to invoke the package binary explicitly: `npx @lark-project/meegle@latest meegle install`. The previous `npx @lark-project/meegle@latest install` form could resolve `install` as the system command instead of the Meegle CLI binary in some agent shells, causing the setup wizard to be skipped.
+- Corrected the npm quick-start commands for the setup wizard. This was superseded by v1.0.14 after verifying the package invocation semantics across npx versions.
 
 ## [v1.0.12] - 2026-06-29
 
@@ -24,7 +30,7 @@ versioned section on each npm release.
 
 ### Added
 
-- `meegle install` now runs a one-stop setup wizard for npm users: install or upgrade the CLI globally, install the AI Agent Skill, configure the host, and start browser or Device Code login. This enables `npx @lark-project/meegle@latest meegle install` as the primary quick-start command.
+- `meegle install` now runs a one-stop setup wizard for npm users: install or upgrade the CLI globally, install the AI Agent Skill, configure the host, and start browser or Device Code login. This enables `npx @lark-project/meegle@latest install` as the primary quick-start command.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Command-line tool for [Meegle](https://meegle.com?utm_source=github&utm_medium=r
 Run the setup wizard:
 
 ```bash
-npx @lark-project/meegle@latest meegle install
+npx @lark-project/meegle@latest install
 ```
 
 The wizard installs or upgrades the CLI globally, installs the AI Agent Skill, configures the Meegle host, and starts login.
@@ -61,7 +61,7 @@ The wizard installs or upgrades the CLI globally, installs the AI Agent Skill, c
 
 ```bash
 # 1. Install CLI + Skill, configure host, and log in
-npx @lark-project/meegle@latest meegle install
+npx @lark-project/meegle@latest install
 
 # 2. View this week's to-dos
 meegle mywork todo --action this_week --page-num 1
@@ -79,7 +79,7 @@ meegle inspect workitem.create
 The default browser OAuth flow requires a real TTY. In CI runners, pipes, and agent shells like Claude Code, run the same setup wizard with an explicit host and Device Code login:
 
 ```bash
-npx -y @lark-project/meegle@latest meegle install --host <host> --device-code --lang en
+npx -y @lark-project/meegle@latest install --host <host> --device-code --lang en
 ```
 
 Examples of `<host>`: `project.feishu.cn`, `meegle.com`, or your self-hosted tenant domain such as `your-tenant.example.com`. The Device Code flow prints an authorization URL; send it to the user and keep the command running until authorization completes.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,7 +50,7 @@
 运行安装向导：
 
 ```bash
-npx @lark-project/meegle@latest meegle install
+npx @lark-project/meegle@latest install
 ```
 
 向导会全局安装或升级 CLI、安装 AI Agent Skill、配置 Meegle host，并启动登录。
@@ -61,7 +61,7 @@ npx @lark-project/meegle@latest meegle install
 
 ```bash
 # 1. 安装 CLI + Skill，配置 host，并登录
-npx @lark-project/meegle@latest meegle install
+npx @lark-project/meegle@latest install
 
 # 2. 查看本周待办
 meegle mywork todo --action this_week --page-num 1
@@ -79,7 +79,7 @@ meegle inspect workitem.create
 默认浏览器 OAuth 流程依赖真实 TTY。在 CI Runner、管道、Claude Code 这类环境里，使用同一个安装向导，但显式传入 host 并启用 Device Code 登录：
 
 ```bash
-npx -y @lark-project/meegle@latest meegle install --host <host> --device-code --lang zh
+npx -y @lark-project/meegle@latest install --host <host> --device-code --lang zh
 ```
 
 `<host>` 示例：`project.feishu.cn`、`meegle.com`，或自建租户域名（如 `your-tenant.example.com`）。

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.