### PR TITLE
fix(auth): preserve credentials during concurrent refresh (v1.0.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.17] - 2026-07-20
+
+### Fixed
+
+- Serialized store-backed OAuth refresh across CLI processes, rejected HTTP 200 error envelopes that omit `access_token`, retried requests with the newly persisted token, and guarded terminal-401 cleanup so a stale process can no longer overwrite or delete fresh credentials ([#40](https://github.com/larksuite/meegle-cli/issues/40)).
+
 ## [v1.0.16] - 2026-07-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -776,6 +776,11 @@ JSON output example (`auth status --format json`) on a rejected token:
 {"authenticated": false, "host": "meegle.com", "reason": "token rejected by server"}
 ```
 
+For credentials managed by `meegle auth login`, token refresh is serialized
+across CLI processes that share a profile. Invalid refresh responses are
+rejected without overwriting the previous credentials, and a late 401 from an
+older process cannot clear a token that another process has already refreshed.
+
 ## Configuration
 
 ### Config File

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -751,6 +751,10 @@ JSON 输出示例（`auth status --format json`），token 被拒：
 {"authenticated": false, "host": "meegle.com", "reason": "token rejected by server"}
 ```
 
+对于 `meegle auth login` 管理的凭据，共用同一 profile 的多个 CLI 进程会串行执行
+token refresh。无效的刷新响应不会覆盖原凭据，旧进程晚到的 401 也不会清除其他进程
+刚刷新成功的新 token。
+
 ## 配置
 
 ### 配置文件

--- a/internal/products/meegle/app.go
+++ b/internal/products/meegle/app.go
@@ -89,6 +89,7 @@ func NewCLIApp(version string, staticCmds *StaticCommands) (*cliapp.App, error) 
 		lister, cache,
 		WithGlobalFlags(MeegleGlobalFlags),
 		WithTokenManager(ident.TokenManager),
+		WithActiveToken(ident.Token),
 		WithIdentitySource(ident.Source),
 		WithForceRefresh(forceRefresh),
 		WithDiscoveryFailureDegradation(true),
@@ -124,6 +125,7 @@ func ResolveMappedCommands() []types.MappedCommand {
 	}
 	setup := NewDynamicRegistrySetup(lister, cache,
 		WithTokenManager(ident.TokenManager),
+		WithActiveToken(ident.Token),
 		WithIdentitySource(ident.Source),
 	)
 	tools, _ := setup.resolveTools(context.Background())

--- a/internal/products/meegle/auth/code_flow.go
+++ b/internal/products/meegle/auth/code_flow.go
@@ -100,6 +100,10 @@ func exchangeToken(ctx context.Context, endpoint string, params url.Values, head
 	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
 		return nil, err
 	}
+	if tr.AccessToken == "" {
+		return nil, meerrors.NewServerError("TOKEN_EXCHANGE_FAILED",
+			"Token exchange response did not include access_token")
+	}
 	return &tr, nil
 }
 

--- a/internal/products/meegle/auth/code_flow_test.go
+++ b/internal/products/meegle/auth/code_flow_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestExchangeTokenRejectsSuccessResponseWithoutAccessToken(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "business error envelope",
+			body: `{"code":10021,"error":{"id":1000050646},"data":{}}`,
+		},
+		{
+			name: "explicit empty token",
+			body: `{"access_token":"","refresh_token":"still-present"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			_, err := exchangeToken(context.Background(), server.URL, url.Values{"grant_type": {"refresh_token"}})
+			if err == nil {
+				t.Fatal("expected missing access_token to fail")
+			}
+			if !strings.Contains(err.Error(), "access_token") {
+				t.Fatalf("expected access_token validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestExchangeTokenAcceptsValidResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"fresh","refresh_token":"refresh","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	got, err := exchangeToken(context.Background(), server.URL, url.Values{"grant_type": {"refresh_token"}})
+	if err != nil {
+		t.Fatalf("exchangeToken failed: %v", err)
+	}
+	if got.AccessToken != "fresh" || got.RefreshToken != "refresh" || got.ExpiresIn != 3600 {
+		t.Fatalf("unexpected token response: %+v", got)
+	}
+}

--- a/internal/products/meegle/auth/fallback_store.go
+++ b/internal/products/meegle/auth/fallback_store.go
@@ -74,3 +74,12 @@ func (s *FallbackStore) Clear() error {
 	}
 	return nil
 }
+
+// WithRefreshLock delegates to the file fallback, whose lock path is stable
+// across processes regardless of which native credential backend is active.
+func (s *FallbackStore) WithRefreshLock(fn func() error) error {
+	if locker, ok := s.fallback.(tokenRefreshLocker); ok {
+		return locker.WithRefreshLock(fn)
+	}
+	return fn()
+}

--- a/internal/products/meegle/auth/file_store.go
+++ b/internal/products/meegle/auth/file_store.go
@@ -10,8 +10,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"time"
 
 	"golang.org/x/crypto/pbkdf2"
 )
@@ -45,6 +49,79 @@ func defaultConfigDir() string {
 }
 
 func (s *FileStore) filePath() string { return filepath.Join(s.dir, s.filename) }
+
+const (
+	refreshLockRetryDelay = 50 * time.Millisecond
+	refreshLockWait       = 30 * time.Second
+	refreshLockStaleAfter = 10 * time.Minute
+)
+
+// WithRefreshLock uses an exclusive lock file so independent CLI processes
+// sharing the same profile cannot refresh and overwrite credentials at once.
+// A crashed process leaves a recoverable stale lock rather than permanently
+// blocking future refreshes.
+func (s *FileStore) WithRefreshLock(fn func() error) error {
+	if err := os.MkdirAll(s.dir, 0700); err != nil {
+		return err
+	}
+	lockPath := s.filePath() + ".refresh.lock"
+	deadline := time.Now().Add(refreshLockWait)
+	for {
+		lockFile, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		if err == nil {
+			owner := fmt.Sprintf("%d-%d\n", os.Getpid(), time.Now().UnixNano())
+			_, _ = lockFile.WriteString(owner)
+			_ = lockFile.Close()
+			defer releaseRefreshLock(lockPath, owner)
+			return fn()
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return fmt.Errorf("create token refresh lock: %w", err)
+		}
+
+		removed, err := removeStaleRefreshLock(lockPath)
+		if err != nil {
+			return err
+		}
+		if removed {
+			continue
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for token refresh lock")
+		}
+		time.Sleep(refreshLockRetryDelay)
+	}
+}
+
+func removeStaleRefreshLock(lockPath string) (bool, error) {
+	info, err := os.Stat(lockPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat token refresh lock: %w", err)
+	}
+	if time.Since(info.ModTime()) <= refreshLockStaleAfter {
+		return false, nil
+	}
+
+	stalePath := fmt.Sprintf("%s.stale-%d-%d", lockPath, os.Getpid(), time.Now().UnixNano())
+	if err := os.Rename(lockPath, stalePath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return true, nil
+		}
+		return false, fmt.Errorf("recover stale token refresh lock: %w", err)
+	}
+	_ = os.Remove(stalePath)
+	return true, nil
+}
+
+func releaseRefreshLock(lockPath, owner string) {
+	data, err := os.ReadFile(lockPath)
+	if err == nil && string(data) == owner {
+		_ = os.Remove(lockPath)
+	}
+}
 
 const machineKeyFile = ".machine-key"
 

--- a/internal/products/meegle/auth/file_store_test.go
+++ b/internal/products/meegle/auth/file_store_test.go
@@ -3,7 +3,10 @@
 
 package auth
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestFileStoreRoundtrip(t *testing.T) {
 	dir := t.TempDir()
@@ -50,5 +53,45 @@ func TestFileStoreLoadMissing(t *testing.T) {
 	}
 	if loaded != nil {
 		t.Error("expected nil for missing file")
+	}
+}
+
+func TestFileStoreRefreshLockSerializesInstances(t *testing.T) {
+	dir := t.TempDir()
+	first := NewFileStore(dir, "shared")
+	second := NewFileStore(dir, "shared")
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondEntered := make(chan struct{})
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- first.WithRefreshLock(func() error {
+			close(firstEntered)
+			<-releaseFirst
+			return nil
+		})
+	}()
+	<-firstEntered
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- second.WithRefreshLock(func() error {
+			close(secondEntered)
+			return nil
+		})
+	}()
+
+	select {
+	case <-secondEntered:
+		t.Fatal("second store entered while the first held the refresh lock")
+	case <-time.After(150 * time.Millisecond):
+	}
+	close(releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/products/meegle/auth/keychain_store.go
+++ b/internal/products/meegle/auth/keychain_store.go
@@ -46,9 +46,10 @@ func (s *KeychainStore) Save(data *TokenData) error {
 	if err != nil {
 		return err
 	}
-	_ = exec.Command("security", "delete-generic-password", "-s", serviceName, "-a", s.account).Run()
 	// Use -X with hex-encoded data passed as command arguments (not via -i
 	// interactive mode) to avoid command injection through the account name.
+	// -U updates an existing item atomically, so do not delete it first: a
+	// concurrent reader must never observe a temporary "no credentials" gap.
 	hexData := hex.EncodeToString(b)
 	cmd := exec.Command("security",
 		"add-generic-password",

--- a/internal/products/meegle/auth/token_manager.go
+++ b/internal/products/meegle/auth/token_manager.go
@@ -50,14 +50,29 @@ func (tm *TokenManager) GetToken() (string, error) {
 		return "", nil
 	}
 	if data.ExpiresAt > 0 && time.Now().UnixMilli() > data.ExpiresAt {
-		refreshed, err := tm.RefreshToken(data)
-		if err != nil {
-			return "", fmt.Errorf("refresh token: %w", err)
-		}
-		if refreshed == nil {
-			return "", nil // not refreshable (missing refresh_token/client_id/host)
-		}
-		return refreshed.AccessToken, nil
+		var token string
+		err := tm.withRefreshLock(func() error {
+			current, err := tm.Store.Load()
+			if err != nil {
+				return err
+			}
+			if current == nil {
+				return nil
+			}
+			if current.ExpiresAt <= 0 || time.Now().UnixMilli() <= current.ExpiresAt {
+				token = current.AccessToken
+				return nil
+			}
+			refreshed, err := tm.RefreshToken(current)
+			if err != nil {
+				return fmt.Errorf("refresh token: %w", err)
+			}
+			if refreshed != nil {
+				token = refreshed.AccessToken
+			}
+			return nil
+		})
+		return token, err
 	}
 	return data.AccessToken, nil
 }
@@ -79,6 +94,9 @@ func (tm *TokenManager) RefreshToken(data *TokenData) (*TokenData, error) {
 	tr, err := exchangeToken(ctx, metadata.TokenEndpoint, params, tm.Headers)
 	if err != nil {
 		return nil, fmt.Errorf("token exchange: %w", err)
+	}
+	if tr == nil || tr.AccessToken == "" {
+		return nil, fmt.Errorf("token exchange response missing access_token")
 	}
 	newData := &TokenData{
 		AccessToken:  tr.AccessToken,
@@ -117,18 +135,70 @@ func (tm *TokenManager) TryRefresh() error {
 	if data == nil {
 		return fmt.Errorf("no token stored")
 	}
-	refreshed, err := tm.RefreshToken(data)
-	if err != nil {
-		return err
-	}
-	if refreshed == nil {
-		return fmt.Errorf("token not refreshable")
-	}
-	return nil
+	snapshot := *data
+	return tm.withRefreshLock(func() error {
+		current, err := tm.Store.Load()
+		if err != nil {
+			return fmt.Errorf("load token after locking: %w", err)
+		}
+		if current == nil {
+			return fmt.Errorf("no token stored")
+		}
+		if current.AccessToken != "" && tokenDataChanged(&snapshot, current) {
+			return nil // another process refreshed while this process waited
+		}
+		refreshed, err := tm.RefreshToken(current)
+		if err != nil {
+			return err
+		}
+		if refreshed == nil {
+			return fmt.Errorf("token not refreshable")
+		}
+		return nil
+	})
 }
 
 func (tm *TokenManager) SaveToken(data *TokenData) error { return tm.Store.Save(data) }
 func (tm *TokenManager) ClearToken() error               { return tm.Store.Clear() }
+
+// ClearTokenIfCurrent prevents a process that received a late 401 with an old
+// token from deleting credentials another process has already refreshed.
+func (tm *TokenManager) ClearTokenIfCurrent(expectedAccessToken string) (bool, error) {
+	if expectedAccessToken == "" {
+		return false, nil
+	}
+	cleared := false
+	err := tm.withRefreshLock(func() error {
+		current, err := tm.Store.Load()
+		if err != nil {
+			return err
+		}
+		if current == nil || current.AccessToken != expectedAccessToken {
+			return nil
+		}
+		if err := tm.Store.Clear(); err != nil {
+			return err
+		}
+		cleared = true
+		return nil
+	})
+	return cleared, err
+}
+
+func (tm *TokenManager) withRefreshLock(fn func() error) error {
+	if locker, ok := tm.Store.(tokenRefreshLocker); ok {
+		return locker.WithRefreshLock(fn)
+	}
+	return fn()
+}
+
+func tokenDataChanged(a, b *TokenData) bool {
+	return a.AccessToken != b.AccessToken ||
+		a.RefreshToken != b.RefreshToken ||
+		a.ClientID != b.ClientID ||
+		a.ExpiresAt != b.ExpiresAt
+}
+
 func (tm *TokenManager) IsAuthenticated() (bool, error) {
 	token, err := tm.GetToken()
 	return token != "", err

--- a/internal/products/meegle/auth/token_manager_test.go
+++ b/internal/products/meegle/auth/token_manager_test.go
@@ -6,7 +6,11 @@ package auth
 import (
 	"bytes"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -47,5 +51,169 @@ func TestTokenManager_PersistRefreshedTokenSilentOnSuccess(t *testing.T) {
 
 	if buf.Len() != 0 {
 		t.Errorf("expected no warning on successful persist, got %q", buf.String())
+	}
+}
+
+type coordinatedTokenStore struct {
+	dataMu    sync.Mutex
+	refreshMu sync.Mutex
+	data      *TokenData
+	loads     atomic.Int32
+	thirdLoad chan struct{}
+	loadOnce  sync.Once
+}
+
+func (s *coordinatedTokenStore) Load() (*TokenData, error) {
+	s.dataMu.Lock()
+	defer s.dataMu.Unlock()
+	count := s.loads.Add(1)
+	if count >= 3 {
+		s.loadOnce.Do(func() { close(s.thirdLoad) })
+	}
+	if s.data == nil {
+		return nil, nil
+	}
+	cloned := *s.data
+	return &cloned, nil
+}
+
+func (s *coordinatedTokenStore) Save(data *TokenData) error {
+	s.dataMu.Lock()
+	defer s.dataMu.Unlock()
+	cloned := *data
+	s.data = &cloned
+	return nil
+}
+
+func (s *coordinatedTokenStore) Clear() error {
+	s.dataMu.Lock()
+	defer s.dataMu.Unlock()
+	s.data = nil
+	return nil
+}
+
+func (s *coordinatedTokenStore) WithRefreshLock(fn func() error) error {
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+	return fn()
+}
+
+func TestTokenManager_TryRefreshSerializesAndReloadsSharedCredentials(t *testing.T) {
+	store := &coordinatedTokenStore{
+		data: &TokenData{
+			AccessToken:  "stale-access",
+			RefreshToken: "shared-refresh",
+			ClientID:     "client-id",
+		},
+		thirdLoad: make(chan struct{}),
+	}
+
+	var tokenCalls atomic.Int32
+	var server *httptest.Server
+	server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_, _ = w.Write([]byte(`{"issuer":"https://issuer.example","authorization_endpoint":"https://issuer.example/auth","registration_endpoint":"https://issuer.example/register","token_endpoint":"` + server.URL + `/token"}`))
+		case "/token":
+			tokenCalls.Add(1)
+			<-store.thirdLoad
+			_, _ = w.Write([]byte(`{"access_token":"fresh-access","refresh_token":"shared-refresh","expires_in":3600}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	previousClient := http.DefaultClient
+	http.DefaultClient = server.Client()
+	t.Cleanup(func() { http.DefaultClient = previousClient })
+	host := strings.TrimPrefix(server.URL, "https://")
+
+	managers := []*TokenManager{NewTokenManager(store, host), NewTokenManager(store, host)}
+	errs := make(chan error, len(managers))
+	for _, manager := range managers {
+		go func(tm *TokenManager) { errs <- tm.TryRefresh() }(manager)
+	}
+	for range managers {
+		if err := <-errs; err != nil {
+			t.Fatalf("TryRefresh failed: %v", err)
+		}
+	}
+
+	if got := tokenCalls.Load(); got != 1 {
+		t.Fatalf("expected one token exchange, got %d", got)
+	}
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded == nil || loaded.AccessToken != "fresh-access" {
+		t.Fatalf("expected fresh credentials, got %+v", loaded)
+	}
+}
+
+func TestTokenManager_InvalidRefreshResponsePreservesStoredCredentials(t *testing.T) {
+	store := &coordinatedTokenStore{
+		data: &TokenData{
+			AccessToken:  "still-valid-locally",
+			RefreshToken: "refresh-token",
+			ClientID:     "client-id",
+		},
+		thirdLoad: make(chan struct{}),
+	}
+
+	var server *httptest.Server
+	server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_, _ = w.Write([]byte(`{"issuer":"https://issuer.example","authorization_endpoint":"https://issuer.example/auth","registration_endpoint":"https://issuer.example/register","token_endpoint":"` + server.URL + `/token"}`))
+		case "/token":
+			_, _ = w.Write([]byte(`{"code":10021,"error":{"id":1000050646},"data":{}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	previousClient := http.DefaultClient
+	http.DefaultClient = server.Client()
+	t.Cleanup(func() { http.DefaultClient = previousClient })
+
+	tm := NewTokenManager(store, strings.TrimPrefix(server.URL, "https://"))
+	original, _ := store.Load()
+	if _, err := tm.RefreshToken(original); err == nil {
+		t.Fatal("expected invalid refresh response to fail")
+	}
+	loaded, _ := store.Load()
+	if loaded == nil || loaded.AccessToken != "still-valid-locally" || loaded.RefreshToken != "refresh-token" {
+		t.Fatalf("invalid refresh response overwrote credentials: %+v", loaded)
+	}
+}
+
+func TestTokenManager_ClearTokenIfCurrent(t *testing.T) {
+	store := &coordinatedTokenStore{
+		data:      &TokenData{AccessToken: "fresh"},
+		thirdLoad: make(chan struct{}),
+	}
+	tm := NewTokenManager(store, "example.com")
+
+	cleared, err := tm.ClearTokenIfCurrent("stale")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleared {
+		t.Fatal("stale process cleared newer credentials")
+	}
+	loaded, _ := store.Load()
+	if loaded == nil || loaded.AccessToken != "fresh" {
+		t.Fatalf("newer credentials were not preserved: %+v", loaded)
+	}
+
+	cleared, err = tm.ClearTokenIfCurrent("fresh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cleared {
+		t.Fatal("current rejected token was not cleared")
 	}
 }

--- a/internal/products/meegle/auth/token_store.go
+++ b/internal/products/meegle/auth/token_store.go
@@ -18,6 +18,13 @@ type TokenStore interface {
 	Clear() error
 }
 
+// tokenRefreshLocker serializes the complete load-refresh-save sequence.
+// Shared process-external stores should provide this optional capability;
+// injected and in-memory test stores may omit it.
+type tokenRefreshLocker interface {
+	WithRefreshLock(func() error) error
+}
+
 // tokenStoreFactory is the pluggable constructor used by CreateTokenStore.
 // Tests swap it via SetTokenStoreFactory so ResolveIdentity (and anything
 // else routing through CreateTokenStore) talks to an isolated store instead

--- a/internal/products/meegle/pipeline.go
+++ b/internal/products/meegle/pipeline.go
@@ -1040,8 +1040,15 @@ func newMcpClientFromState(state *pipeline.PipelineContext) *mcpclient.Client {
 		httpHeaders.Set(k, v)
 	}
 
+	tokenFunc := func() (string, error) { return token, nil }
+	if tm != nil {
+		// Store-backed credentials must be read again for the retry after a
+		// successful refresh; retaining the session snapshot would resend the
+		// rejected token and turn a successful refresh into another 401.
+		tokenFunc = tm.GetToken
+	}
 	opts := []mcpclient.Option{
-		mcpclient.WithToken(func() (string, error) { return token, nil }),
+		mcpclient.WithToken(tokenFunc),
 		mcpclient.WithHeaders(httpHeaders),
 	}
 	if authHeader != "" {
@@ -1050,21 +1057,9 @@ func newMcpClientFromState(state *pipeline.PipelineContext) *mcpclient.Client {
 	if ua, _ := state.OutputConfig["mcp.user_agent"].(string); ua != "" {
 		opts = append(opts, mcpclient.WithUserAgent(ua))
 	}
-	opts = append(opts, mcpclient.WithRefreshFunc(func() error {
-		if tm == nil {
-			return fmt.Errorf("no token manager")
-		}
-		store, _ := state.OutputConfig["mcp.store"].(auth.TokenStore)
-		if store == nil {
-			return fmt.Errorf("no token store")
-		}
-		data, err := store.Load()
-		if err != nil || data == nil {
-			return fmt.Errorf("no token data")
-		}
-		_, err = tm.RefreshToken(data)
-		return err
-	}))
+	if tm != nil {
+		opts = append(opts, mcpclient.WithRefreshFunc(tm.TryRefresh))
+	}
 	return mcpclient.New(baseURL, opts...)
 }
 

--- a/internal/products/meegle/pipeline_test.go
+++ b/internal/products/meegle/pipeline_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/larksuite/meegle-cli/internal/products/meegle/auth"
 	meerrors "github.com/larksuite/meegle-cli/internal/products/meegle/errors"
 	"github.com/larksuite/meegle-cli/internal/products/meegle/mcpclient"
 	"github.com/larksuite/meegle-cli/pkg/framework/executor"
@@ -503,6 +504,87 @@ func TestMcpExecutorStep_CustomAuthHeader_OverridesStaticHeader(t *testing.T) {
 	}
 	if capturedCustom != "live-token" {
 		t.Errorf("expected live-token (from tokenFunc), got %q", capturedCustom)
+	}
+}
+
+func TestMcpExecutorStep_RefreshRetryUsesFreshStoredToken(t *testing.T) {
+	store := &memTokenStore{data: &auth.TokenData{
+		AccessToken:  "stale-token",
+		RefreshToken: "refresh-token",
+		ClientID:     "client-id",
+	}}
+
+	var oauthServer *httptest.Server
+	oauthServer = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                 "https://issuer.example",
+				"authorization_endpoint": "https://issuer.example/auth",
+				"registration_endpoint":  "https://issuer.example/register",
+				"token_endpoint":         oauthServer.URL + "/token",
+			})
+		case "/token":
+			_, _ = w.Write([]byte(`{"access_token":"fresh-token","refresh_token":"refresh-token","expires_in":3600}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer oauthServer.Close()
+
+	previousClient := http.DefaultClient
+	http.DefaultClient = oauthServer.Client()
+	t.Cleanup(func() { http.DefaultClient = previousClient })
+
+	var seenTokens []string
+	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		seenTokens = append(seenTokens, token)
+		if token == "stale-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if token != "fresh-token" {
+			t.Errorf("unexpected token %q", token)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var body struct {
+			ID int64 `json:"id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      body.ID,
+			"result":  map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}},
+		})
+	}))
+	defer mcpServer.Close()
+
+	tm := auth.NewTokenManager(store, strings.TrimPrefix(oauthServer.URL, "https://"))
+	step := &McpExecutorStep{}
+	state := &pipeline.PipelineContext{
+		Parsed: &router.ParsedCommand{
+			FullPath: []string{"workitem", "get-brief"},
+			Node:     &registry.CommandNode{HandlerRef: "get_work_item"},
+			Flags:    map[string]any{},
+		},
+		Values: map[string]any{},
+		OutputConfig: map[string]any{
+			"mcp.host":          "ignored.example.com",
+			"mcp.server_url":    mcpServer.URL,
+			"mcp.token":         "stale-token",
+			"mcp.headers":       map[string]string{},
+			"mcp.store":         auth.TokenStore(store),
+			"mcp.token_manager": tm,
+		},
+	}
+
+	if err := step.Execute(context.Background(), state); err != nil {
+		t.Fatalf("executor step failed after refresh: %v", err)
+	}
+	if len(seenTokens) != 2 || seenTokens[0] != "stale-token" || seenTokens[1] != "fresh-token" {
+		t.Fatalf("expected retry with refreshed token, got %v", seenTokens)
 	}
 }
 

--- a/internal/products/meegle/registry.go
+++ b/internal/products/meegle/registry.go
@@ -55,6 +55,7 @@ type DynamicRegistrySetup struct {
 	client                   discovery.ToolLister
 	cache                    *ToolCache
 	tokenManager             *auth.TokenManager
+	activeToken              string
 	source                   IdentitySource
 	globalFlags              []registry.FlagDef
 	commands                 []types.MappedCommand // populated by Setup, read by pipeline steps
@@ -78,6 +79,14 @@ func WithGlobalFlags(flags []registry.FlagDef) RegistryOption {
 func WithTokenManager(tm *auth.TokenManager) RegistryOption {
 	return func(s *DynamicRegistrySetup) {
 		s.tokenManager = tm
+	}
+}
+
+// WithActiveToken records the token used to construct the discovery client.
+// A terminal 401 may clear the store only if this exact token is still there.
+func WithActiveToken(token string) RegistryOption {
+	return func(s *DynamicRegistrySetup) {
+		s.activeToken = token
 	}
 }
 
@@ -189,10 +198,11 @@ func (s *DynamicRegistrySetup) resolveTools(ctx context.Context) ([]types.ToolDe
 			// the user which knob to rotate. SDK callers (SourceUnset with an
 			// injected client) need the 401 to surface so they can react.
 			if meerrors.IsUnauthorized(err) && s.source != SourceUnset {
-				// ClearToken only when we actually own the credential — env
-				// and config tokens must be rotated by the user out-of-band.
+				// Clear only a store token that is still the one rejected by
+				// this process. Another process may already have refreshed it.
+				// Env/config tokens remain caller-owned and are never cleared.
 				if s.source == SourceStore && s.tokenManager != nil {
-					_ = s.tokenManager.ClearToken()
+					_, _ = s.tokenManager.ClearTokenIfCurrent(s.activeToken)
 				}
 				s.authFailed = true
 				return nil, nil

--- a/internal/products/meegle/registry_test.go
+++ b/internal/products/meegle/registry_test.go
@@ -340,6 +340,7 @@ func TestDynamicRegistrySetup_Graceful401_ClearsTokenAndFlagsAuth(t *testing.T) 
 
 	setup := NewDynamicRegistrySetup(lister, nil,
 		WithTokenManager(tm),
+		WithActiveToken("stale"),
 		WithIdentitySource(SourceStore),
 	)
 
@@ -361,6 +362,28 @@ func TestDynamicRegistrySetup_Graceful401_ClearsTokenAndFlagsAuth(t *testing.T) 
 	}
 	if !store.cleared {
 		t.Error("expected token store to be cleared after terminal 401")
+	}
+}
+
+func TestDynamicRegistrySetup_Graceful401_PreservesNewerStoredToken(t *testing.T) {
+	lister := &unauthorizedLister{}
+	store := &memTokenStore{data: &auth.TokenData{AccessToken: "fresh"}}
+	tm := auth.NewTokenManager(store, "example.com")
+
+	setup := NewDynamicRegistrySetup(lister, nil,
+		WithTokenManager(tm),
+		WithActiveToken("stale"),
+		WithIdentitySource(SourceStore),
+	)
+
+	if _, err := setup.Setup(context.Background()); err != nil {
+		t.Fatalf("expected graceful degradation on 401, got error: %v", err)
+	}
+	if store.cleared {
+		t.Fatal("stale process cleared a token refreshed by another process")
+	}
+	if store.data == nil || store.data.AccessToken != "fresh" {
+		t.Fatalf("newer token was not preserved: %+v", store.data)
 	}
 }
 

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.