### PR TITLE
fix: keep URLs copyable in JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.19] - 2026-08-04
+
+### Fixed
+
+- JSON and NDJSON output now keep URL query separators such as `&` literal instead of escaping them as `\u0026`, so returned login and verification URLs can be copied directly.
+
 ## [v1.0.18] - 2026-07-24
 
 ### Added

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",

--- a/pkg/framework/output/encoders/json.go
+++ b/pkg/framework/output/encoders/json.go
@@ -21,7 +21,7 @@ func EncodeJSON(data any) ([]byte, error) {
 		}
 		return pretty.Bytes(), nil
 	}
-	encoded, err := json.Marshal(data)
+	encoded, err := marshalJSON(data)
 	if err != nil {
 		return nil, err
 	}
@@ -30,4 +30,18 @@ func EncodeJSON(data any) ([]byte, error) {
 		return encoded, nil
 	}
 	return pretty.Bytes(), nil
+}
+
+// marshalJSON encodes CLI output without HTML escaping. CLI JSON is written
+// to a terminal or pipe rather than embedded in HTML, so keeping characters
+// such as '&' literal makes URLs directly copyable while remaining valid JSON.
+// Encoder.Encode appends a newline, which is removed so callers control framing.
+func marshalJSON(data any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(data); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
 }

--- a/pkg/framework/output/encoders/json_test.go
+++ b/pkg/framework/output/encoders/json_test.go
@@ -53,3 +53,40 @@ func TestEncodeJSON_EmptyArray(t *testing.T) {
 		t.Fatalf("got: %q", out)
 	}
 }
+
+func TestEncodeJSON_URLRemainsCopyable(t *testing.T) {
+	const authURL = "https://meego.example.com/b/auth/mcp?channel=meegle-cli&mode=device&usercode=ABCD-1234"
+
+	out, err := EncodeJSON(map[string]any{"verification_uri_complete": authURL})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(string(out), authURL) {
+		t.Fatalf("expected literal URL in output, got: %s", out)
+	}
+	if strings.Contains(string(out), `\u0026`) {
+		t.Fatalf("expected ampersands to remain unescaped, got: %s", out)
+	}
+}
+
+func BenchmarkEncodeJSON_Array1000(b *testing.B) {
+	data := make([]any, 1000)
+	for i := range data {
+		data[i] = map[string]any{
+			"id":   i,
+			"name": "benchmark-record",
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := EncodeJSON(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(out) == 0 {
+			b.Fatal("expected output")
+		}
+	}
+}

--- a/pkg/framework/output/encoders/ndjson.go
+++ b/pkg/framework/output/encoders/ndjson.go
@@ -13,29 +13,30 @@ import (
 //   - Non-array input: single line.
 //   - Empty array: zero bytes.
 //
-// Strings with embedded newlines are escaped by json.Marshal.
+// Strings with embedded newlines are escaped by encoding/json.
 func EncodeNDJSON(data any) ([]byte, error) {
 	normalized := normalize(data)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+
 	if arr, ok := normalized.([]any); ok {
 		if len(arr) == 0 {
 			return nil, nil
 		}
-		var buf bytes.Buffer
+		// Reuse one encoder so array inputs do not allocate an encoder and
+		// buffer for every record.
 		for _, item := range arr {
-			enc, err := json.Marshal(item)
-			if err != nil {
+			if err := enc.Encode(item); err != nil {
 				return nil, err
 			}
-			buf.Write(enc)
-			buf.WriteByte('\n')
 		}
 		return buf.Bytes(), nil
 	}
-	enc, err := json.Marshal(normalized)
-	if err != nil {
+	if err := enc.Encode(normalized); err != nil {
 		return nil, err
 	}
-	return append(enc, '\n'), nil
+	return buf.Bytes(), nil
 }
 
 // normalize decodes json.RawMessage so array detection works uniformly.

--- a/pkg/framework/output/encoders/ndjson_test.go
+++ b/pkg/framework/output/encoders/ndjson_test.go
@@ -4,9 +4,16 @@
 package encoders
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
+
+type failingJSONMarshaler struct{}
+
+func (failingJSONMarshaler) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("encode failed")
+}
 
 func TestEncodeNDJSON_ArrayOfObjects(t *testing.T) {
 	data := []any{
@@ -17,12 +24,9 @@ func TestEncodeNDJSON_ArrayOfObjects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	lines := strings.Split(strings.TrimSuffix(string(out), "\n"), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("want 2 lines, got %d: %q", len(lines), out)
-	}
-	if !strings.Contains(lines[0], `"id":1`) || !strings.Contains(lines[1], `"id":2`) {
-		t.Fatalf("lines: %q", lines)
+	const want = "{\"id\":1}\n{\"id\":2}\n"
+	if string(out) != want {
+		t.Fatalf("want %q, got %q", want, out)
 	}
 }
 
@@ -32,9 +36,9 @@ func TestEncodeNDJSON_SingleObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	lines := strings.Split(strings.TrimSuffix(string(out), "\n"), "\n")
-	if len(lines) != 1 {
-		t.Fatalf("want 1 line, got %d: %q", len(lines), out)
+	const want = "{\"id\":1}\n"
+	if string(out) != want {
+		t.Fatalf("want %q, got %q", want, out)
 	}
 }
 
@@ -53,7 +57,7 @@ func TestEncodeNDJSON_EmptyArray(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(strings.TrimSpace(string(out))) != 0 {
+	if len(out) != 0 {
 		t.Fatalf("want empty, got: %q", out)
 	}
 }
@@ -70,5 +74,67 @@ func TestEncodeNDJSON_StringNewlineEscaped(t *testing.T) {
 	}
 	if !strings.Contains(trimmed, `\n`) {
 		t.Fatalf("newline not escaped: %q", out)
+	}
+}
+
+func TestEncodeNDJSON_URLRemainsCopyable(t *testing.T) {
+	const authURL = "https://meego.example.com/b/auth/mcp?channel=meegle-cli&mode=device&usercode=ABCD-1234"
+
+	out, err := EncodeNDJSON(map[string]any{"verification_uri_complete": authURL})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(string(out), authURL) {
+		t.Fatalf("expected literal URL in output, got: %s", out)
+	}
+	if strings.Contains(string(out), `\u0026`) {
+		t.Fatalf("expected ampersands to remain unescaped, got: %s", out)
+	}
+}
+
+func TestEncodeNDJSON_ArrayURLRemainsCopyable(t *testing.T) {
+	const authURL = "https://meego.example.com/b/auth/mcp?channel=meegle-cli&mode=device&usercode=ABCD-1234"
+
+	out, err := EncodeNDJSON([]any{map[string]any{"verification_uri_complete": authURL}})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(string(out), authURL) {
+		t.Fatalf("expected literal URL in output, got: %s", out)
+	}
+	if strings.Contains(string(out), `\u0026`) {
+		t.Fatalf("expected ampersands to remain unescaped, got: %s", out)
+	}
+}
+
+func TestEncodeNDJSON_ArrayEncodingErrorReturnsNoOutput(t *testing.T) {
+	out, err := EncodeNDJSON([]any{map[string]any{"id": 1}, failingJSONMarshaler{}})
+	if err == nil {
+		t.Fatal("expected encoding error")
+	}
+	if out != nil {
+		t.Fatalf("expected nil output on error, got: %q", out)
+	}
+}
+
+func BenchmarkEncodeNDJSON_Array1000(b *testing.B) {
+	data := make([]any, 1000)
+	for i := range data {
+		data[i] = map[string]any{
+			"id":   i,
+			"name": "benchmark-record",
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out, err := EncodeNDJSON(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(out) == 0 {
+			b.Fatal("expected output")
+		}
 	}
 }


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.