### PR TITLE
fix: keep Facade command SDK MCP-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Full race suite
-        run: go test ./... -race -count=1 -timeout 300s
-      - name: Repeated shuffled extension tests
-        run: go test -shuffle=on -count=3 -timeout 300s ./cmd ./extension/credential ./extension/platform ./extension/transport ./internal/extension/platform ./internal/extension/transport ./internal/products/meegle ./internal/products/meegle/mcpclient ./internal/products/meegle/sdk ./pkg/runtime/cliapp ./pkg/sdk/meegle
+      - run: make test
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: make test
+      - name: Full race suite
+        run: go test ./... -race -count=1 -timeout 300s
+      - name: Repeated shuffled extension tests
+        run: go test -shuffle=on -count=3 -timeout 300s ./cmd ./extension/credential ./extension/platform ./extension/transport ./internal/extension/platform ./internal/extension/transport ./internal/products/meegle ./internal/products/meegle/mcpclient ./internal/products/meegle/sdk ./pkg/runtime/cliapp ./pkg/sdk/meegle
 
   lint:
     name: Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versioned section on each npm release.
 
 ## [Unreleased]
 
+## [v1.0.22] - 2026-08-27
+
+### Fixed
+
+- Restored the Facade command-string Go SDK to its MCP-only contract: local CLI API commands such as `ai-handoff` and `preference handoff` remain available in the npm-distributed `meegle` CLI but are no longer registered or routed by the remote RPC SDK.
+
 ## [v1.0.21] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -849,9 +849,10 @@ escape sequences retain their backslash.
 This decoding only applies to programmatic command-string entry points such as
 `CommandClient.Execute` and `ExecuteCommandString`. The `meegle` binary receives
 an argument array from the shell, so normal shell quoting rules apply there.
-The command-string SDK registers both MCP-discovered commands and local CLI API
-commands, including `ai-handoff` and `preference handoff`; direct `CallTool`
-continues to address MCP tools only.
+The command-string Go SDK used by Facade for remote RPC execution registers only
+MCP-discovered commands. Local CLI API commands such as `ai-handoff` and
+`preference handoff` are available only in the npm-distributed `meegle` CLI;
+direct `CallTool` also continues to address MCP tools only.
 
 ## Authentication
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -818,8 +818,9 @@ meegle inspect workitem.create
 该解码只作用于 `CommandClient.Execute`、`ExecuteCommandString` 等程序化
 命令字符串入口。`meegle` 二进制直接接收 shell 解析后的参数数组，因此仍遵循
 对应 shell 的引号和转义规则。
-命令字符串 SDK 会同时注册 MCP 动态发现命令和本地 CLI API 命令，包括
-`ai-handoff` 与 `preference handoff`；直接调用 `CallTool` 时仍然只访问 MCP tool。
+供 Facade 远程 RPC 调用的命令字符串 Go SDK 只注册 MCP 动态发现命令。
+`ai-handoff`、`preference handoff` 等本地 CLI API 命令只在 npm 分发的
+`meegle` CLI 中提供；直接调用 `CallTool` 时也仍然只访问 MCP tool。
 
 ## 认证
 

--- a/internal/products/meegle/sdk/exec.go
+++ b/internal/products/meegle/sdk/exec.go
@@ -14,7 +14,6 @@ import (
 	meegle "github.com/larksuite/meegle-cli/internal/products/meegle"
 	"github.com/larksuite/meegle-cli/internal/products/meegle/mcpclient"
 	"github.com/larksuite/meegle-cli/pkg/framework/executor"
-	"github.com/larksuite/meegle-cli/pkg/framework/registry"
 	"github.com/larksuite/meegle-cli/pkg/runtime/cliapp"
 )
 
@@ -197,10 +196,12 @@ func NewCommandClient(host string, opts ...CommandClientOption) (*CommandClient,
 	mcpOpts := cfg.mcpClientOpts()
 
 	client := mcpclient.New(serverURL, mcpOpts...)
+	// The command-string SDK is the MCP-only entry point used by Facade for
+	// remote RPC execution. Local CLI API commands belong to the npm-distributed
+	// meegle binary and must not be registered here.
 	dynamicSetup := meegle.NewDynamicRegistrySetup(client, nil,
 		meegle.WithGlobalFlags(meegle.MeegleGlobalFlags),
 	)
-	registrySetup := registry.NewCompositeSetup(dynamicSetup, meegle.NewMeegleLocalSetup())
 
 	placeholderExec := executor.Func(func(_ context.Context, _ *executor.Request) (*executor.RawResult, error) {
 		return nil, fmt.Errorf("executor not implemented: please execute commands through pipeline steps")
@@ -208,7 +209,7 @@ func NewCommandClient(host string, opts ...CommandClientOption) (*CommandClient,
 
 	app, err := cliapp.New(
 		cliapp.WithAppName("meegle"),
-		cliapp.WithSetup(registrySetup),
+		cliapp.WithSetup(dynamicSetup),
 		cliapp.WithExecutor(placeholderExec),
 		cliapp.WithPipelineFactory(newSDKPipelineFactory(cfg, dynamicSetup)),
 	)

--- a/internal/products/meegle/sdk/exec_test.go
+++ b/internal/products/meegle/sdk/exec_test.go
@@ -289,7 +289,7 @@ func TestNewCommandClient_RegistersMetadataDefinedToolFromToolsList(t *testing.T
 	}
 }
 
-func TestNewCommandClient_ExecutesLocalCLIAPICommand(t *testing.T) {
+func TestNewCommandClient_DoesNotRegisterLocalCLIAPICommands(t *testing.T) {
 	var calls atomic.Int32
 	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		calls.Add(1)
@@ -329,13 +329,13 @@ func TestNewCommandClient_ExecutesLocalCLIAPICommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewCommandClient() error = %v", err)
 	}
-	output, err := client.Execute(context.Background(),
-		`meegle ai-handoff create-link --query "summarize" --dry-run --format json`)
-	if err != nil {
-		t.Fatalf("Execute() error = %v", err)
-	}
-	if !strings.Contains(string(output), `"dry_run": true`) {
-		t.Fatalf("Execute() output = %s", output)
+	for _, command := range []string{
+		`meegle ai-handoff create-link --query "summarize" --dry-run --format json`,
+		`meegle preference handoff auto --dry-run --format json`,
+	} {
+		if _, err := client.Execute(context.Background(), command); err == nil {
+			t.Fatalf("Execute(%q) succeeded; local CLI API commands must not be registered in the SDK", command)
+		}
 	}
 	if calls.Load() != 1 {
 		t.Fatalf("MCP calls = %d, want discovery only", calls.Load())

--- a/internal/products/meegle/sdk/pipeline.go
+++ b/internal/products/meegle/sdk/pipeline.go
@@ -13,8 +13,8 @@ import (
 	"github.com/larksuite/meegle-cli/pkg/runtime/cliapp"
 )
 
-// sdkInjectStep pre-injects the shared command session plus the MCP endpoint.
-// Backend runtimes consume the shared session without reading CLI profiles.
+// sdkInjectStep pre-injects the MCP endpoint used by the Facade command-string
+// SDK. This SDK is MCP-only and must not expose local CLI API commands.
 type sdkInjectStep struct {
 	cfg *ClientConfig
 }
@@ -31,14 +31,8 @@ func (s *sdkInjectStep) Execute(ctx context.Context, state *pipeline.PipelineCon
 	state.OutputConfig["mcp.token"] = token
 	state.OutputConfig["mcp.server_url"] = s.cfg.serverURL()
 	state.OutputConfig["mcp.injected"] = true
-	state.OutputConfig["session.host"] = s.cfg.Host
-	state.OutputConfig["session.headers"] = s.cfg.Headers
-	state.OutputConfig["session.token"] = token
-	state.OutputConfig["session.injected"] = true
 	if s.cfg.UserAgent != "" {
-		userAgent := s.cfg.buildUserAgent()
-		state.OutputConfig["mcp.user_agent"] = userAgent
-		state.OutputConfig["session.user_agent"] = userAgent
+		state.OutputConfig["mcp.user_agent"] = s.cfg.buildUserAgent()
 	}
 	return nil
 }
@@ -50,10 +44,13 @@ func newSDKPipelineFactory(cfg *ClientConfig, setup *meegle.DynamicRegistrySetup
 	if setup != nil {
 		commandsFunc = setup.MappedCommands
 	}
-	session := &meegle.SessionStep{}
+	// Keep the SDK runtime MCP-only even though the npm CLI configures both MCP
+	// and CLI API runtimes. The registry above this pipeline contains only
+	// dynamically discovered MCP commands, so a CLI API runtime is deliberately
+	// absent here.
 	resolver := meegle.NewCommandRuntimeResolver(
-		&meegle.MCPRuntime{Session: session, CommandsFunc: commandsFunc},
-		&meegle.CLIAPIRuntime{Session: session},
+		&meegle.MCPRuntime{CommandsFunc: commandsFunc},
+		nil,
 	)
 	return func(appCfg cliapp.Config) (*pipeline.Pipeline, error) {
 		return &pipeline.Pipeline{Steps: []pipeline.PipelineStep{

--- a/internal/products/meegle/sdk/pipeline_test.go
+++ b/internal/products/meegle/sdk/pipeline_test.go
@@ -57,8 +57,10 @@ func TestSDKInjectStep_SetsOutputConfig(t *testing.T) {
 	if state.OutputConfig["mcp.server_url"] != "https://meegle.com/mcp_server/v1" {
 		t.Errorf("unexpected server_url: %v", state.OutputConfig["mcp.server_url"])
 	}
-	if state.OutputConfig["session.host"] != "meegle.com" || state.OutputConfig["session.token"] != "my-token" {
-		t.Errorf("shared session was not injected: %#v", state.OutputConfig)
+	for _, key := range []string{"session.host", "session.headers", "session.token", "session.injected"} {
+		if _, ok := state.OutputConfig[key]; ok {
+			t.Errorf("SDK injected CLI API session key %q: %#v", key, state.OutputConfig)
+		}
 	}
 }
 

--- a/npm/meegle/package.json
+++ b/npm/meegle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lark-project/meegle",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Agent-First CLI for Meegle (Lark Project)",
   "license": "MIT",
   "homepage": "https://github.com/larksuite/meegle-cli#readme",


### PR DESCRIPTION
Synced from internal `main`. Generated by `scripts/sync-pr.sh`.